### PR TITLE
chore: adiciona o módulo de configurações & corrige `PrismaService`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,4 @@ pids
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
-/generated/prisma
+/prisma/generated

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^11.0.1",
+        "@nestjs/config": "4.0.4",
         "@nestjs/core": "^11.0.1",
         "@nestjs/platform-express": "^11.0.1",
         "@prisma/adapter-pg": "7.7.0",
@@ -21,7 +22,8 @@
         "pg": "8.20.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
-        "uuid": "^13.0.0"
+        "uuid": "^13.0.0",
+        "zod": "4.3.6"
       },
       "devDependencies": {
         "@nestjs/cli": "^11.0.0",
@@ -1033,6 +1035,60 @@
         "class-validator": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/config": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-4.0.4.tgz",
+      "integrity": "sha512-CJPjNitr0bAufSEnRe2N+JbnVmMmDoo6hvKCPzXgZoGwJSmp/dZPk9f/RMbuD/+Q1ZJPjwsRpq0vxna++Knwow==",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "17.4.1",
+        "dotenv-expand": "12.0.3",
+        "lodash": "4.18.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "rxjs": "^7.1.0"
+      }
+    },
+    "node_modules/@nestjs/config/node_modules/dotenv": {
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
+      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@nestjs/config/node_modules/dotenv-expand": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.3.tgz",
+      "integrity": "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@nestjs/config/node_modules/dotenv-expand/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/@nestjs/core": {
@@ -5612,7 +5668,6 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/log-symbols": {
@@ -7563,16 +7618,6 @@
         "node": "^20.0.0 || >=22.0.0"
       }
     },
-    "node_modules/tmpl": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
-      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.0.0 || >=22.0.0"
-      }
-    },
     "node_modules/tinyrainbow": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
@@ -8380,6 +8425,15 @@
       "dependencies": {
         "grammex": "^3.1.11",
         "graphmatch": "^1.1.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,18 +23,20 @@
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",
+    "@nestjs/config": "4.0.4",
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
     "@prisma/adapter-pg": "7.7.0",
     "@prisma/client": "7.7.0",
+    "argon2": "0.44.0",
     "dotenv": "17.4.2",
     "dotenv-expand": "13.0.0",
-    "argon2": "0.44.0",
     "fp-ts": "^2.16.11",
     "pg": "8.20.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
-    "uuid": "^13.0.0"
+    "uuid": "^13.0.0",
+    "zod": "4.3.6"
   },
   "devDependencies": {
     "@nestjs/cli": "^11.0.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider = "prisma-client"
-  output   = "../generated/prisma"
+  output   = "./generated"
 }
 
 datasource db {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,9 +2,11 @@ import { Module } from "@nestjs/common";
 import { AppController } from "./app.controller";
 import { AppService } from "./app.service";
 import { Argon2Module } from "./infra/argon2/argon2.module";
+import { ConfigModule } from "@nestjs/config";
+import datastoreConfig from "@/configs/datastore.config";
 
 @Module({
-  imports: [Argon2Module],
+  imports: [ConfigModule.forRoot({ isGlobal: true, load: [datastoreConfig] }), Argon2Module],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/configs/datastore.config.ts
+++ b/src/configs/datastore.config.ts
@@ -1,0 +1,11 @@
+import { registerAs } from "@nestjs/config";
+import z from "zod";
+
+const schema = z.object({
+  DATABASE_URL: z.url("DATABASE_URL is a required environment variable and must be a valid URL."),
+});
+
+export default registerAs("datastore", () => {
+  const result = schema.parse(process.env);
+  return result;
+});

--- a/src/infra/prisma/prisma.ts
+++ b/src/infra/prisma/prisma.ts
@@ -1,10 +1,21 @@
-import { Injectable, OnModuleInit, OnModuleDestroy } from "@nestjs/common";
+import datastoreConfig from "@/configs/datastore.config";
+import { Injectable, OnModuleInit, OnModuleDestroy, Inject } from "@nestjs/common";
+import { type ConfigType } from "@nestjs/config";
 import { PrismaClient } from "@prisma-gen/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 
 @Injectable()
-export class PrismaService extends PrismaClient implements OnModuleInit {
-  public async onModuleInit() {
+export class PrismaService extends PrismaClient implements OnModuleInit, OnModuleDestroy {
+  public constructor(@Inject(datastoreConfig.KEY) config: ConfigType<typeof datastoreConfig>) {
+    const connectionString = config.DATABASE_URL;
+    super({ adapter: new PrismaPg({ connectionString }) });
+  }
+
+  async onModuleInit() {
     await this.$connect();
+  }
+
+  async onModuleDestroy() {
+    await this.$disconnect();
   }
 }

--- a/src/infra/prisma/prisma.ts
+++ b/src/infra/prisma/prisma.ts
@@ -1,5 +1,6 @@
-import { Injectable, OnModuleInit } from "@nestjs/common";
-import { PrismaClient } from "../../../generated/prisma/client";
+import { Injectable, OnModuleInit, OnModuleDestroy } from "@nestjs/common";
+import { PrismaClient } from "@prisma-gen/client";
+import { PrismaPg } from "@prisma/adapter-pg";
 
 @Injectable()
 export class PrismaService extends PrismaClient implements OnModuleInit {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,11 @@
-import { NestFactory } from '@nestjs/core';
-import { AppModule } from './app.module';
+import { NestFactory } from "@nestjs/core";
+import { AppModule } from "./app.module";
+import { expand } from "dotenv-expand";
+import { config } from "dotenv";
 
 async function bootstrap() {
+  expand(config());
+
   const app = await NestFactory.create(AppModule);
   await app.listen(process.env.PORT ?? 3000);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,8 +22,9 @@
     "strictBindCallApply": false,
     "noFallthroughCasesInSwitch": false,
     "paths": {
-      "@/*": ["./src/*"] 
+      "@/*": ["./src/*"],
+      "@prisma-gen/*": ["./prisma/generated/*"]
     },
     "types": ["node", "vitest/globals"]
-  },
+  }
 }


### PR DESCRIPTION
Esse PR configura as variáveis de ambiente no sistema, introduz o módulo de configurações do Nest.JS, inicializa a configuração mínima de banco de dados (a partir de variáveis de ambiente), e corrige o `PrismaService` inicializando o `PrismaClient` corretamente. (Na nova versão do Prisma, é necessário configurar o URL do banco de dados via construtor do `PrismaClient`, em contraste às versões anteriores em que tal configuração era feita no arquivo `schema.prisma`.)

As seguintes bibliotecas foram adicionadas como dependência:
- zod
- @nestjs/config

Além disso, os artefatos do prisma agora são gerados no diretório `/prisma/generate` ao invés de `/generate/prisma`.