### PR TITLE
feat: adiciona Swagger

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,7 @@
 # App
 APP_NAME=TEA PTS
 APP_URL=http://localhost:3000
+APP_VERSION=
 
 # JWT
 JWT_PUBLIC_KEY=

--- a/.github/docs/guia-de-desenvolvimento/dtos.md
+++ b/.github/docs/guia-de-desenvolvimento/dtos.md
@@ -41,12 +41,26 @@ configurar o código HTTP que deve ser retornado diante de um erro de validaçã
 Ele pode ser aplicado sobre DTOs, _controllers_ ou _handlers_ específicos. Por padrão, o código
 HTTP `422` (_Unprocessable Entity_) é utilizado.
 
+## Swagger
+
+Os DTOs são utilizados pelo Swagger para documentar as entradas esperadas por cada _endpoint_. Para
+que eles possam ser utilizados, todas as propriedades também devem ser decoradas com `@ApiProperty()`.
+
+Procure fornecer uma descrição para a propriedade (em inglês) e, quando possível, um exemplo. (Se
+a propriedade é um texto localizado, forneça exemplos em português.) Outras configurações podem ser
+aplicadas para uma propriedade.
+
+Confira: [Tipos & Parâmetros (NestJS - Swagger)]
+
+[Tipos & Parâmetros (NestJS - Swagger)]: https://docs.nestjs.com/openapi/types-and-parameters
+
 ## Exemplo
 
 ### DTO Simples
 
 ```ts
 import { DTO } from "@/infra/http/dto";
+import { ApiProperty } from "@nestjs/swagger";
 import { Expose } from "class-transformer";
 import z from "zod";
 
@@ -60,9 +74,11 @@ type LoginSchema = z.infer<typeof schema>;
 export class LoginDto extends DTO implements LoginSchema {
   protected schema = schema;
 
+  @ApiProperty({ description: "The account's registered e-mail address." })
   @Expose()
   public readonly email!: string;
 
+  @ApiProperty({ description: "The account's password." })
   @Expose()
   public readonly password!: string;
 }

--- a/.github/docs/guia-de-desenvolvimento/objetos-e-arquitetura.md
+++ b/.github/docs/guia-de-desenvolvimento/objetos-e-arquitetura.md
@@ -80,14 +80,15 @@ Um query handler **nunca** cria ou modifica um dado, apenas visualiza.
 
 ### Presenters
 
-Presenters são responsáveis por restringir quais dados de um [DTO] devem ser visíveis dado algum contexto. Eles realizam
-a transformação final dos dados.
+Presenters são responsáveis por restringir quais dados de um [DTO] devem ser visíveis dado algum contexto. Eles
+realizam a transformação final dos dados.
 
 > Por exemplo: uma prévia de uma trajetória terapêutica não precisa conter todos os dados de um [DTO] de trajetória
 > terapêutica, naturalmente.
 
-Assim como [DTOs], esses não performam nenhuma operação e servem como uma sacola de dados prontas para ser exibidos
-para o usuário final.
+Veja mais detalhes sobre _presenters_ em seu [documento específico].
+
+[documento específico]: ./presenters.md
 
 ### Controllers
 

--- a/.github/docs/guia-de-desenvolvimento/presenters.md
+++ b/.github/docs/guia-de-desenvolvimento/presenters.md
@@ -1,0 +1,105 @@
+# Presenters
+
+Presenters são responsáveis por apresentar os dados de saída, visando omitir campos sensíveis (ou
+fora do escopo do _endpoint_) e/ou realizar outras transformações de apresentação. Podemos
+enxergá-los como DTOs de saída.
+
+Um presenter não precisa implementar nenhuma interface em particular, no entanto é esperado que
+sigam o padrão descrito neste documento. A não conformância com este padrão somente pode dificultar
+ou alterar o modo como ele é utilizado nos _controllers_.
+
+## O objeto
+
+Espera-se que um _presenter_ seja uma classe extremamente simples:
+
+- Ela somente **deve** possuir variáveis públicas e de leitura (`public readonly`)
+- A classe apresentadora **deve** ser composta somente por tipos primitivos ou outros _presenters_
+- Uma classe apresentadora **não deve** possuir nenhum método além daqueles especificados neste documento
+- O construtor de uma classe apresentadora **deve** ser privado e **não deveria** performar nenhuma lógica
+  complexa, apenas atribuir os valores às propriedades.
+
+## O método `present`
+
+Uma classe apresentadora **deve** possuir um método estático `present`, que tome uma entidade
+de domínio como parâmetro e transforme-a em uma instância de si própria — isto é, apresente a entidade.
+
+O método pode ser síncrono ou assíncrono, conforme houver necessidade.
+
+## Swagger
+
+As classes apresentadoras **devem** ter todas as suas propriedades decoradas com `@ApiProperty(...)`.
+Descrições **devem** ser providenciadas para cada propriedade. Exemplos **deveriam** ser providenciados para
+cada propriedade.
+
+## Exemplos
+
+### Simples
+
+```ts
+import { Account } from "@/modules/identity/entities/account.aggregate";
+import { ApiProperty } from "@nestjs/swagger";
+
+export class AccountPresenter {
+  @ApiProperty({ example: "...", description: "..." }) public readonly id!: string;
+  @ApiProperty({ example: "...", description: "..." }) public readonly name!: string;
+  @ApiProperty({ example: "...", description: "..." }) public readonly email!: string;
+  @ApiProperty({ example: "...", description: "..." }) public readonly lastUpdatedAt?: Date;
+  @ApiProperty({ example: "...", description: "..." }) public readonly createdAt!: Date;
+
+  private constructor(props: AccountPresenter) {
+    Object.assign(this, props);
+  }
+
+  public static present(account: Account) {
+    return new this({
+      id: account.getId().toString(),
+      name: account.getName(),
+      email: account.getEmail(),
+      createdAt: account.getCreatedAt(),
+      lastUpdatedAt: account.getLastUpdatedAt(),
+    });
+  }
+}
+```
+
+Os valores de exemplo, bem como as descrições, foram omitidos para manter a simplicidade do
+documento.
+
+Observe que neste apresentador o campo `passwordHash` da `Account` foi omitido, e o tipo
+`UUID` precisou ser transformado em uma string (tipo primitivo), assim como discutimos anteriormente.
+
+Observe, ainda, que para resolver erros do Typescript, utilizamos o operador de _non-null assertion_
+em todas as propriedades obrigatórias — não é necessário adicioná-lo nas opcionais, já que não são
+obrigatórias —, pois utilizamos um atalho (`Object.assign`) para atribuir os valores das propriedades.
+
+Tomar o próprio _presenter_ como parâmetro do construtor privado está ok: como é um objeto simples e
+sem métodos, o compilador do Typescript não acusará erros se passarmos um objeto plano ao invés de
+uma instância, desde que o objeto implemente a classe como se fosse uma interface. Tomamos proveito
+deste mecanismo.
+
+### Composto
+
+```ts
+export class ComposedPresenter {
+  @ApiProperty({ example: "...", description: "..." })
+  public readonly somethingComplex!: SomeComplexObjectPresenter;
+
+  @ApiProperty({ example: "...", description: "..." })
+  public readonly primitiveValue!: string;
+
+  private constructor(props: ComposedPresenter) {
+    Object.assign(this, props);
+  }
+
+  public static present(composedEntity: ComposedEntity, complexEntity: ComplexEntity) {
+    return new this({
+      somethingComplex: SomeComplexObjectPresenter.present(complexEntity),
+      primitiveValue: composedEntity.someValue.toString(),
+    });
+  }
+}
+```
+
+Neste exemplo, utilizamos um outro _presenter_ para compor a classe apresentadora `ComposedPresenter`.
+Além disso, apresentamos um método `present` que toma mais de 1 parâmetro, o que é totalmente permitido,
+desde que facilite a utilização do apresentador.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/jwt": "11.0.2",
         "@nestjs/passport": "11.0.5",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/swagger": "11.4.2",
         "@prisma/adapter-pg": "7.7.0",
         "@prisma/client": "7.7.0",
         "argon2": "0.44.0",
@@ -981,6 +982,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -1355,6 +1362,26 @@
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.1.tgz",
+      "integrity": "sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0 || ^0.15.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/passport": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-11.0.5.tgz",
@@ -1405,6 +1432,39 @@
       },
       "peerDependenciesMeta": {
         "prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.4.2.tgz",
+      "integrity": "sha512-aBihEogDMj/bLEcaqhkvyX/ZVWUw/bmnhKzR0zwUoyGJikvZyaq7rOPYl/H7Lxkkr3c90SJxyuv1AX2UT1WKlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "@nestjs/mapped-types": "2.1.1",
+        "js-yaml": "4.1.1",
+        "lodash": "4.18.1",
+        "path-to-regexp": "8.4.2",
+        "swagger-ui-dist": "5.32.4"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0 || ^9.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
           "optional": true
         }
       }
@@ -2887,6 +2947,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -4006,7 +4073,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
@@ -6567,7 +6633,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -9099,6 +9164,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.4",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.4.tgz",
+      "integrity": "sha512-0AADFFQNJzExEN49SrD/34Nn9cxNxVLiydYl2MBwSZFPVXNkVwC/EFAjoezGGqE8oDegiDC+p47t8lKObCinMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@nestjs/jwt": "11.0.2",
     "@nestjs/passport": "11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/swagger": "11.4.2",
     "@prisma/adapter-pg": "7.7.0",
     "@prisma/client": "7.7.0",
     "argon2": "0.44.0",

--- a/src/configs/app.config.ts
+++ b/src/configs/app.config.ts
@@ -4,6 +4,7 @@ import z from "zod";
 const schema = z.object({
   APP_NAME: z.string("APP_NAME is a required environment variable and must be a string."),
   APP_URL: z.url("URL must be a valid URL string."),
+  APP_VERSION: z.string().optional(),
 });
 
 export default registerAs("app", () => schema.parse(process.env));

--- a/src/infra/auth/presenters/tokens.presenter.ts
+++ b/src/infra/auth/presenters/tokens.presenter.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class JWTokensPresenter {
+  @ApiProperty({ description: "The JWT used for accessing protected resources." })
+  public readonly accessToken!: string;
+
+  @ApiProperty({
+    description: "The JWT used for requesting another access token upon access token expiration.",
+  })
+  public readonly refreshToken!: string;
+
+  private constructor(props: JWTokensPresenter) {
+    Object.assign(this, props);
+  }
+
+  // This is a dead-simple presenter. It might seem unecessarily complexity to introduce this
+  // presenter that does nothing actually (and it is), but it makes total sense for the other
+  // presenters to follow this pattern. This is a special case that didn't even need a presenter,
+  // but it's useful for us to have this presenter class for Swagger usage, hence here we are.
+  public static present(tokens: JWTokensPresenter) {
+    return new JWTokensPresenter(tokens);
+  }
+}

--- a/src/infra/http/exceptions/basic.presenter.ts
+++ b/src/infra/http/exceptions/basic.presenter.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class BasicExceptionPresenter {
+  @ApiProperty({
+    example: "Uma mensagem descritiva explicando o que ocasionou o erro.",
+    description: "A human-readable and user-targeted error message.",
+  })
+  public readonly message!: string;
+
+  private constructor(props: BasicExceptionPresenter) {
+    Object.assign(this, props);
+  }
+
+  public static present(error: BasicExceptionPresenter) {
+    return new this(error);
+  }
+}

--- a/src/infra/http/exceptions/exceptions-factory.ts
+++ b/src/infra/http/exceptions/exceptions-factory.ts
@@ -5,6 +5,7 @@ import { IrrecoverableError } from "@/common/errors/irrecoverable.error";
 import { ResourceNotFoundError } from "@/common/errors/resource-not-found.error";
 import { UnauthorizedError } from "@/common/errors/unauthorized.error";
 import { ValidationErrorsBag } from "@/common/errors/validation-errors-bag.error";
+import { BasicExceptionPresenter } from "@/infra/http/exceptions/basic.presenter";
 import { ValidationErrorsBagException } from "@/infra/http/exceptions/validation/exception";
 import {
   BadRequestException,
@@ -19,8 +20,8 @@ const internalServerErrorMessage =
 
 function fromError(error: BaseError | ValidationErrorsBag): never {
   if (error instanceof UnauthorizedError) {
-    const { message, cause } = error;
-    throw new UnauthorizedException({ message }, { cause });
+    const { cause } = error;
+    throw new UnauthorizedException(BasicExceptionPresenter.present(error), { cause });
   }
 
   if (error instanceof InvalidArgumentError) {
@@ -47,7 +48,8 @@ function fromError(error: BaseError | ValidationErrorsBag): never {
   }
 
   console.error("An unexpected error occurred and was not properly handled.", { cause: error });
-  throw new InternalServerErrorException({ message: internalServerErrorMessage });
+  const internalError = BasicExceptionPresenter.present({ message: internalServerErrorMessage });
+  throw new InternalServerErrorException(internalError);
 }
 
 export default {

--- a/src/infra/http/exceptions/validation/filter.ts
+++ b/src/infra/http/exceptions/validation/filter.ts
@@ -1,4 +1,5 @@
 import { ValidationErrorsBagException } from "@/infra/http/exceptions/validation/exception";
+import { ValidationErrorBagPresenter } from "@/infra/http/exceptions/validation/presenter";
 import { serializeValidationErrorsBag } from "@/infra/http/exceptions/validation/serialize-validation-errors";
 import { ArgumentsHost, Catch, ExceptionFilter, Injectable, Scope } from "@nestjs/common";
 
@@ -13,6 +14,6 @@ export class ValidationErrorsBagExceptionFilter implements ExceptionFilter {
     const ctx = host.switchToHttp();
     const status = exception.getStatus();
     const errors = serializeValidationErrorsBag(exception.validationErrors.getErrors());
-    return ctx.getResponse().status(status).json({ errors, status });
+    return ctx.getResponse().status(status).json(new ValidationErrorBagPresenter({ errors }));
   }
 }

--- a/src/infra/http/exceptions/validation/presenter.ts
+++ b/src/infra/http/exceptions/validation/presenter.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class ValidationErrorBagPresenter {
+  @ApiProperty({
+    example: {
+      email: ["O e-mail fornecido é inválido."],
+      password: ["A senha é um campo obrigatório."],
+    },
+    type: "object",
+    additionalProperties: {
+      type: "array",
+      description: "Grouped validation error messages related to this field.",
+      items: {
+        type: "string",
+        description: "A human-readable text explaining what is wrong with this input.",
+      },
+    },
+    description:
+      "A map of every invalid field and their validation error messages. Note that valid fields are not included in the map.",
+  })
+  public readonly errors!: Record<string, string[]>;
+
+  public constructor(props: ValidationErrorBagPresenter) {
+    Object.assign(this, props);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,11 +2,36 @@ import { NestFactory } from "@nestjs/core";
 import { AppModule } from "./app.module";
 import { expand } from "dotenv-expand";
 import { config } from "dotenv";
+import { DocumentBuilder, SwaggerDocumentOptions, SwaggerModule } from "@nestjs/swagger";
+import appConfig from "@/configs/app.config";
+import type { ConfigType } from "@nestjs/config";
+import { BasicExceptionPresenter } from "@/infra/http/exceptions/basic.presenter";
 
 async function bootstrap() {
   expand(config());
 
   const app = await NestFactory.create(AppModule);
+
+  const appConfigs: ConfigType<typeof appConfig> = app.get(appConfig.KEY);
+
+  const swaggerConfig = new DocumentBuilder()
+    .setTitle("TEA PTS API v1")
+    .setVersion(appConfigs.APP_VERSION ?? "development")
+    .addGlobalResponse({
+      status: 500,
+      type: BasicExceptionPresenter,
+      description: "Some server internal error has occurred.",
+    })
+    .addBearerAuth()
+    .build();
+
+  const swaggerOptions = {
+    operationIdFactory: (_controllerKey: string, methodKey: string) => methodKey,
+  } satisfies SwaggerDocumentOptions;
+
+  const document = SwaggerModule.createDocument(app, swaggerConfig, swaggerOptions);
+  SwaggerModule.setup("/api-docs/v1", app, document);
+
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/src/modules/identity/dtos/login.dto.ts
+++ b/src/modules/identity/dtos/login.dto.ts
@@ -1,6 +1,7 @@
 import { DTO } from "@/infra/http/dto";
 import { ConfigValidation } from "@/infra/http/validation-provider";
 import { HttpStatus } from "@nestjs/common";
+import { ApiProperty } from "@nestjs/swagger";
 import { Expose } from "class-transformer";
 import z from "zod";
 
@@ -15,9 +16,11 @@ type LoginSchema = z.infer<typeof schema>;
 export class LoginDto extends DTO implements LoginSchema {
   protected schema = schema;
 
+  @ApiProperty({ description: "The account's registered e-mail address." })
   @Expose()
   public readonly email!: string;
 
+  @ApiProperty({ description: "The account's password." })
   @Expose()
   public readonly password!: string;
 }

--- a/src/modules/identity/sessions.controller.ts
+++ b/src/modules/identity/sessions.controller.ts
@@ -1,9 +1,17 @@
 import { AssignTokenService } from "@/infra/auth/assign-token.service";
 import { Public } from "@/infra/auth/decorators/public-route";
+import { JWTokensPresenter } from "@/infra/auth/presenters/tokens.presenter";
+import { BasicExceptionPresenter } from "@/infra/http/exceptions/basic.presenter";
 import exceptionsFactory from "@/infra/http/exceptions/exceptions-factory";
+import { ValidationErrorBagPresenter } from "@/infra/http/exceptions/validation/presenter";
 import { LoginDto } from "@/modules/identity/dtos/login.dto";
 import { AuthenticateAccountService } from "@/modules/identity/services/authenticate-account.service";
 import { Body, Controller, HttpCode, HttpStatus, Post } from "@nestjs/common";
+import {
+  ApiOkResponse,
+  ApiUnauthorizedResponse,
+  ApiUnprocessableEntityResponse,
+} from "@nestjs/swagger";
 import { taskEither as te } from "fp-ts";
 import { pipe } from "fp-ts/lib/function";
 
@@ -16,6 +24,18 @@ export class SessionsController {
 
   @Public()
   @Post("login")
+  @ApiOkResponse({
+    description: "The successful authentication response.",
+    type: JWTokensPresenter,
+  })
+  @ApiUnprocessableEntityResponse({
+    type: ValidationErrorBagPresenter,
+    description: "Some of the inputs contain validation errors.",
+  })
+  @ApiUnauthorizedResponse({
+    type: BasicExceptionPresenter,
+    description: "Provided credentials are wrong.",
+  })
   @HttpCode(HttpStatus.OK)
   public login(@Body() loginDto: LoginDto) {
     return pipe(
@@ -25,6 +45,7 @@ export class SessionsController {
           plainPassword: loginDto.password,
         }),
       te.chainW((account) => () => this.tokensService.execute({ account })),
+      te.map(JWTokensPresenter.present),
       te.getOrElse(exceptionsFactory.fromError),
     )();
   }


### PR DESCRIPTION
Esse PR configura o Swagger, documenta o endpoint de Login com os novos decoradores do Swagger, atualiza a documentação de DTOs para instruir sobre como integrar o Swagger com os DTOs e, por fim, adiciona uma documentação sobre _presenters_, ensinando como criá-los e integrá-los com o Swagger.