### PR TITLE
feat: adiciona entidades relacionadas ao PTS

### DIFF
--- a/prisma/migrations/20260511014347_rename_therapeutic_journey_model/migration.sql
+++ b/prisma/migrations/20260511014347_rename_therapeutic_journey_model/migration.sql
@@ -1,0 +1,28 @@
+/*
+  Warnings:
+
+  - You are about to drop the `therapeutic_journey` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "professional_participating_on_therapeutic_journey" DROP CONSTRAINT "professional_participating_on_therapeutic_journey_therapeu_fkey";
+
+-- DropForeignKey
+ALTER TABLE "therapeutic_journey" DROP CONSTRAINT "therapeutic_journey_responsible_professional_id_fkey";
+
+-- DropTable
+DROP TABLE "therapeutic_journey";
+
+-- CreateTable
+CREATE TABLE "projeto_terapeutico_singular" (
+    "id" TEXT NOT NULL,
+    "responsible_professional_id" TEXT NOT NULL,
+
+    CONSTRAINT "projeto_terapeutico_singular_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "professional_participating_on_therapeutic_journey" ADD CONSTRAINT "professional_participating_on_therapeutic_journey_therapeu_fkey" FOREIGN KEY ("therapeutic_journey_id") REFERENCES "projeto_terapeutico_singular"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "projeto_terapeutico_singular" ADD CONSTRAINT "projeto_terapeutico_singular_responsible_professional_id_fkey" FOREIGN KEY ("responsible_professional_id") REFERENCES "professional"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260515012504_complement_pts_and_add_activity_and_documents/migration.sql
+++ b/prisma/migrations/20260515012504_complement_pts_and_add_activity_and_documents/migration.sql
@@ -1,0 +1,76 @@
+/*
+  Warnings:
+
+  - Added the required column `patient_id` to the `projeto_terapeutico_singular` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `socialSituation` to the `projeto_terapeutico_singular` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `status` to the `projeto_terapeutico_singular` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "pts_state_e" AS ENUM ('draft', 'planning', 'running', 'concluded', 'cancelled', 'rejected');
+
+-- CreateEnum
+CREATE TYPE "activity_state_e" AS ENUM ('suggested', 'rejected', 'running', 'archived');
+
+-- AlterTable
+ALTER TABLE "projeto_terapeutico_singular" ADD COLUMN     "acceptedAt" TIMESTAMP(3),
+ADD COLUMN     "beganAt" TIMESTAMP(3),
+ADD COLUMN     "cancelledAt" TIMESTAMP(3),
+ADD COLUMN     "concludedAt" TIMESTAMP(3),
+ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "patient_id" TEXT NOT NULL,
+ADD COLUMN     "rejectedAt" TIMESTAMP(3),
+ADD COLUMN     "socialSituation" TEXT NOT NULL,
+ADD COLUMN     "status" "pts_state_e" NOT NULL;
+
+-- CreateTable
+CREATE TABLE "document" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" VARCHAR(4096),
+    "document_url" VARCHAR(16384) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "last_updated_at" TIMESTAMP(3),
+    "patient_account_id" TEXT NOT NULL,
+
+    CONSTRAINT "document_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "activity_referring_to_document_rel" (
+    "activity_id" TEXT NOT NULL,
+    "document_id" TEXT NOT NULL,
+
+    CONSTRAINT "activity_referring_to_document_rel_pkey" PRIMARY KEY ("activity_id","document_id")
+);
+
+-- CreateTable
+CREATE TABLE "activity" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "frequency" JSONB NOT NULL,
+    "state" "activity_state_e" NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL,
+    "assignee_professional_id" TEXT NOT NULL,
+    "projeto_terapeutico_singular_id" TEXT,
+
+    CONSTRAINT "activity_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "projeto_terapeutico_singular" ADD CONSTRAINT "projeto_terapeutico_singular_patient_id_fkey" FOREIGN KEY ("patient_id") REFERENCES "patient"("accountId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "document" ADD CONSTRAINT "document_patient_account_id_fkey" FOREIGN KEY ("patient_account_id") REFERENCES "patient"("accountId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "activity_referring_to_document_rel" ADD CONSTRAINT "activity_referring_to_document_rel_activity_id_fkey" FOREIGN KEY ("activity_id") REFERENCES "activity"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "activity_referring_to_document_rel" ADD CONSTRAINT "activity_referring_to_document_rel_document_id_fkey" FOREIGN KEY ("document_id") REFERENCES "document"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "activity" ADD CONSTRAINT "activity_assignee_professional_id_fkey" FOREIGN KEY ("assignee_professional_id") REFERENCES "professional"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "activity" ADD CONSTRAINT "activity_projeto_terapeutico_singular_id_fkey" FOREIGN KEY ("projeto_terapeutico_singular_id") REFERENCES "projeto_terapeutico_singular"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,8 +40,8 @@ model Professional {
   accountId String
   account   Account @relation(fields: [accountId], references: [id], onDelete: Cascade)
 
-  leadingJourneys       TherapeuticJourney[]                            @relation("ResponsibleRelation")
-  journeysWhereIsMember ProfessionalParticipatingOnTherapeuticJourney[]
+  leadingJourneys       ProjetoTerapeuticoSingular[]     @relation("ResponsibleRelation")
+  journeysWhereIsMember ProfessionalParticipatingOnPTS[]
 
   @@map("professional")
 }
@@ -54,24 +54,24 @@ enum Specialism {
   @@map("specialism_e")
 }
 
-model ProfessionalParticipatingOnTherapeuticJourney {
+model ProfessionalParticipatingOnPTS {
   professionalId String       @map("professional_id")
   professional   Professional @relation(fields: [professionalId], references: [id])
 
-  therapeuticJourneyId String             @map("therapeutic_journey_id")
-  therapeuticJourney   TherapeuticJourney @relation(fields: [therapeuticJourneyId], references: [id])
+  ProjetoTerapeuticoSingularId String                     @map("therapeutic_journey_id")
+  ProjetoTerapeuticoSingular   ProjetoTerapeuticoSingular @relation(fields: [ProjetoTerapeuticoSingularId], references: [id])
 
-  @@id([professionalId, therapeuticJourneyId])
+  @@id([professionalId, ProjetoTerapeuticoSingularId])
   @@map("professional_participating_on_therapeutic_journey")
 }
 
-model TherapeuticJourney {
+model ProjetoTerapeuticoSingular {
   id String @id @default(uuid())
 
   responsibleProfessionalId String       @map("responsible_professional_id")
   responsibleProfessional   Professional @relation(name: "ResponsibleRelation", fields: [responsibleProfessionalId], references: [id])
 
-  multidisciplinaryTeam ProfessionalParticipatingOnTherapeuticJourney[]
+  multidisciplinaryTeam ProfessionalParticipatingOnPTS[]
 
-  @@map("therapeutic_journey")
+  @@map("projeto_terapeutico_singular")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,7 +28,9 @@ model Patient {
   accountId       String @id
   supportContacts Json[]
 
-  account Account @relation(fields: [accountId], references: [id], onDelete: Cascade)
+  account                        Account                      @relation(fields: [accountId], references: [id], onDelete: Cascade)
+  documents                      Document[]
+  projetosTerapeuticosSingulares ProjetoTerapeuticoSingular[]
 
   @@map("patient")
 }
@@ -42,6 +44,7 @@ model Professional {
 
   leadingJourneys       ProjetoTerapeuticoSingular[]     @relation("ResponsibleRelation")
   journeysWhereIsMember ProfessionalParticipatingOnPTS[]
+  activities            Activity[]
 
   @@map("professional")
 }
@@ -65,13 +68,91 @@ model ProfessionalParticipatingOnPTS {
   @@map("professional_participating_on_therapeutic_journey")
 }
 
+enum PtsStatus {
+  Draft     @map("draft")
+  Planning  @map("planning")
+  Running   @map("running")
+  Concluded @map("concluded")
+  Cancelled @map("cancelled")
+  Rejected  @map("rejected")
+
+  @@map("pts_state_e")
+}
+
 model ProjetoTerapeuticoSingular {
-  id String @id @default(uuid())
+  id              String    @id @default(uuid())
+  socialSituation String    @db.Text
+  status          PtsStatus
+  createdAt       DateTime  @default(now()) @map("createdAt")
+  acceptedAt      DateTime? @map("acceptedAt")
+  rejectedAt      DateTime? @map("rejectedAt")
+  beganAt         DateTime? @map("beganAt")
+  concludedAt     DateTime? @map("concludedAt")
+  cancelledAt     DateTime? @map("cancelledAt")
+
+  patientId String  @map("patient_id")
+  patient   Patient @relation(fields: [patientId], references: [accountId])
 
   responsibleProfessionalId String       @map("responsible_professional_id")
   responsibleProfessional   Professional @relation(name: "ResponsibleRelation", fields: [responsibleProfessionalId], references: [id])
 
   multidisciplinaryTeam ProfessionalParticipatingOnPTS[]
 
+  activities Activity[]
+
   @@map("projeto_terapeutico_singular")
+}
+
+model Document {
+  id            String    @id @default(uuid())
+  title         String
+  description   String?   @db.VarChar(4096)
+  documentUrl   String    @map("document_url") @db.VarChar(16384)
+  createdAt     DateTime  @default(now()) @map("created_at")
+  lastUpdatedAt DateTime? @map("last_updated_at")
+
+  patient          Patient @relation(fields: [patientAccountId], references: [accountId])
+  patientAccountId String  @map("patient_account_id")
+
+  activityReferringToDocuments ActivityReferringToDocument[]
+
+  @@map("document")
+}
+
+model ActivityReferringToDocument {
+  activityId String   @map("activity_id")
+  activity   Activity @relation(fields: [activityId], references: [id])
+
+  documentId String   @map("document_id")
+  document   Document @relation(fields: [documentId], references: [id])
+
+  @@id([activityId, documentId])
+  @@map("activity_referring_to_document_rel")
+}
+
+enum ActivityState {
+  Suggested @map("suggested")
+  Rejected  @map("rejected")
+  Running   @map("running")
+  Archived  @map("archived")
+
+  @@map("activity_state_e")
+}
+
+model Activity {
+  id        String        @id @default(uuid())
+  title     String
+  frequency Json
+  state     ActivityState
+  createdAt DateTime      @map("created_at")
+
+  assigneeProfessionalId String       @map("assignee_professional_id")
+  assigneeProfessional   Professional @relation(fields: [assigneeProfessionalId], references: [id])
+
+  activityReferringToDocuments ActivityReferringToDocument[]
+
+  projetoTerapeuticoSingular   ProjetoTerapeuticoSingular? @relation(fields: [projetoTerapeuticoSingularId], references: [id])
+  projetoTerapeuticoSingularId String?                     @map("projeto_terapeutico_singular_id")
+
+  @@map("activity")
 }

--- a/src/common/entities/aggregate-root.ts
+++ b/src/common/entities/aggregate-root.ts
@@ -1,8 +1,5 @@
 export abstract class AggregateRoot<TProps extends object> {
   protected constructor(protected readonly _props: TProps) {}
 
-  public equals(other: AggregateRoot<TProps>) {
-    if (this === other) return true;
-    if (!(other instanceof this.constructor)) return false;
-  }
+  public abstract equals(other: AggregateRoot<TProps>);
 }

--- a/src/common/entities/value-object.ts
+++ b/src/common/entities/value-object.ts
@@ -1,12 +1,9 @@
+import { isDeepStrictEqual } from "node:util";
+
 export abstract class ValueObject {
   public equals(other: ValueObject) {
+    if (this === other) return true;
     if (!(other instanceof this.constructor)) return false;
-
-    for (const [key, value] of Object.entries(this)) {
-      const hasEquivalentKey = Object.hasOwn(other, key) && other[key] === value;
-      if (!hasEquivalentKey) return false;
-    }
-
-    return true;
+    return isDeepStrictEqual(this, other);
   }
 }

--- a/src/common/time/errors/frequency-integrity-violation.error.ts
+++ b/src/common/time/errors/frequency-integrity-violation.error.ts
@@ -1,0 +1,6 @@
+import { BadRequestError } from "@/common/errors/bad-request.error";
+
+/**
+ * Represents a frequency inconsistency.
+ */
+export class FrequencyIntegrityViolationError extends BadRequestError {}

--- a/src/common/time/value-objects/frequency.spec.ts
+++ b/src/common/time/value-objects/frequency.spec.ts
@@ -1,0 +1,54 @@
+import { FrequencyIntegrityViolationError } from "@/common/time/errors/frequency-integrity-violation.error";
+import { Frequency, TimeUnit } from "@/common/time/value-objects/frequency.vo";
+import { either } from "fp-ts";
+
+describe("Frequency", () => {
+  it.each([
+    Frequency.create({ times: 1.5, interval: TimeUnit.Day }),
+    Frequency.create({ times: 1, interval: [2.5, TimeUnit.Day] }),
+  ])("should not allow non-integer amount of times", (frequencyResult) => {
+    assert(either.isLeft(frequencyResult));
+    expect(frequencyResult.left).toBeInstanceOf(FrequencyIntegrityViolationError);
+  });
+
+  it.each([
+    Frequency.create({ times: 0, interval: TimeUnit.Day }),
+    Frequency.create({ times: -1, interval: TimeUnit.Day }),
+    Frequency.create({ times: 1, interval: [0, TimeUnit.Day] }),
+    Frequency.create({ times: 1, interval: [-10, TimeUnit.Day] }),
+  ])("should not allow zero or negative amount of time unit values", (frequencyResult) => {
+    assert(either.isLeft(frequencyResult));
+    expect(frequencyResult.left).toBeInstanceOf(FrequencyIntegrityViolationError);
+  });
+
+  it.each(
+    [
+      [
+        Frequency.createUnchecked({ interval: TimeUnit.Day, times: 1 }),
+        Frequency.createUnchecked({ interval: [1, TimeUnit.Day], times: 1 }),
+      ],
+      [
+        Frequency.createUnchecked({
+          interval: [8, TimeUnit.Hour],
+          times: 1,
+          duration: [2, TimeUnit.Week],
+        }),
+        Frequency.createUnchecked({
+          interval: [8, TimeUnit.Hour],
+          times: 1,
+          duration: [2, TimeUnit.Week],
+        }),
+      ],
+      (() => {
+        const frequency = Frequency.createUnchecked({ interval: TimeUnit.Day, times: 2 });
+        return [frequency, frequency];
+      })(),
+    ].map((pairs) => [pairs]),
+  )(
+    "should correctly assert equality between equivalent frequencies for %#: %j",
+    ([freq1, freq2]) => {
+      expect(freq1.equals(freq2)).toBe(true);
+      expect(freq2.equals(freq1)).toBe(true);
+    },
+  );
+});

--- a/src/common/time/value-objects/frequency.vo.ts
+++ b/src/common/time/value-objects/frequency.vo.ts
@@ -31,7 +31,7 @@ interface IFrequency {
  * Frequency.create({
  *  times: 3,
  *  interval: TimeUnit.Day,
- *  duration: [2, TimeUnit.Month].
+ *  duration: [2, TimeUnit.Month]
  * })
  * ```
  *

--- a/src/common/time/value-objects/frequency.vo.ts
+++ b/src/common/time/value-objects/frequency.vo.ts
@@ -1,0 +1,100 @@
+import { ValueObject } from "@/common/entities/value-object";
+import { FrequencyIntegrityViolationError } from "@/common/time/errors/frequency-integrity-violation.error";
+import { either as e } from "fp-ts";
+import { pipe } from "fp-ts/lib/function";
+
+export enum TimeUnit {
+  Second = "second",
+  Minute = "minute",
+  Hour = "hour",
+  Day = "day",
+  Week = "week",
+  Month = "month",
+  Year = "year",
+}
+
+export type TimeInterval = TimeUnit | readonly [number, TimeUnit];
+export type TimeDuration = readonly [number, TimeUnit];
+
+interface IFrequency {
+  readonly times: number;
+  readonly interval: TimeInterval;
+  readonly duration?: TimeDuration;
+}
+
+/**
+ * Represents a time frequency (with amount of times, a duration and an interval)
+ *
+ * @example
+ * ```ts
+ * // 3 times per day for 2 months
+ * Frequency.create({
+ *  times: 3,
+ *  interval: TimeUnit.Day,
+ *  duration: [2, TimeUnit.Month].
+ * })
+ * ```
+ *
+ * @example
+ * ```ts
+ * // once every three weeks for a year
+ * Frequency.create({
+ *  times: 1,
+ *  interval: [3, TimeUnit.Week],
+ *  duration: [1, TimeUnit.Year]
+ * })
+ * ```
+ */
+export class Frequency extends ValueObject implements IFrequency {
+  private constructor(
+    public readonly times: number,
+    public readonly interval: TimeInterval,
+    public readonly duration?: TimeDuration,
+  ) {
+    super();
+  }
+  public static create({ interval, times, duration }: IFrequency) {
+    // Destructuring com fallback limpa a necessidade de checar Array.isArray múltiplas vezes
+    const [intervalNum, intervalUnit] = Array.isArray(interval) ? interval : [1, interval];
+
+    return pipe(
+      e.Do,
+      e.bind("timesNum", () => this.ensurePositiveInteger(times, "A quantidade de vezes")),
+      e.bind("intervalNum", () => this.ensurePositiveInteger(intervalNum, "O intervalo")),
+      e.bind("durationNum", () =>
+        duration ? this.ensurePositiveInteger(duration[0], "A duração") : e.right(undefined),
+      ),
+      e.map(({ durationNum, intervalNum, timesNum }) => {
+        let resolvedDuration: TimeDuration | undefined = undefined;
+        if (durationNum && duration) resolvedDuration = [durationNum, duration[1]] as const;
+
+        const normalizedInterval = this.normalizeInterval([intervalNum, intervalUnit]);
+
+        return new Frequency(timesNum, normalizedInterval, resolvedDuration);
+      }),
+    );
+  }
+
+  /**
+   * Creates a frequency without performing any check.
+   *
+   * @note This should only be used to rehydrate an instance of frequency from some
+   * previously existing frequency payload.
+   */
+  public static createUnchecked({ interval, times, duration }: IFrequency) {
+    const normalizedInterval = this.normalizeInterval(interval);
+    return new Frequency(times, normalizedInterval, duration);
+  }
+
+  private static ensurePositiveInteger(value: number, label: string) {
+    if (value > 0 && Number.isInteger(value)) return e.right(value);
+
+    const message = `${label} precisa ser um valor inteiro e positivo (maior que zero).`;
+    return e.left(new FrequencyIntegrityViolationError({ message }));
+  }
+
+  private static normalizeInterval(interval: TimeInterval) {
+    if (Array.isArray(interval) && interval[0] === 1) return interval[1];
+    return interval;
+  }
+}

--- a/src/common/time/value-objects/frequency.vo.ts
+++ b/src/common/time/value-objects/frequency.vo.ts
@@ -46,16 +46,19 @@ interface IFrequency {
  * ```
  */
 export class Frequency extends ValueObject implements IFrequency {
+  public readonly interval: TimeInterval;
   private constructor(
     public readonly times: number,
-    public readonly interval: TimeInterval,
+    interval: TimeInterval,
     public readonly duration?: TimeDuration,
   ) {
     super();
+    this.interval = Frequency.normalizeInterval(interval);
   }
   public static create({ interval, times, duration }: IFrequency) {
-    // Destructuring com fallback limpa a necessidade de checar Array.isArray múltiplas vezes
-    const [intervalNum, intervalUnit] = Array.isArray(interval) ? interval : [1, interval];
+    const [intervalNum, intervalUnit] = Array.isArray(interval)
+      ? (interval as Exclude<TimeInterval, TimeUnit>) // typescript shit to get type hints for the destructured vars
+      : ([1, interval as TimeUnit] as const);
 
     return pipe(
       e.Do,
@@ -67,10 +70,9 @@ export class Frequency extends ValueObject implements IFrequency {
       e.map(({ durationNum, intervalNum, timesNum }) => {
         let resolvedDuration: TimeDuration | undefined = undefined;
         if (durationNum && duration) resolvedDuration = [durationNum, duration[1]] as const;
+        const resolvedInterval = [intervalNum, intervalUnit] as const;
 
-        const normalizedInterval = this.normalizeInterval([intervalNum, intervalUnit]);
-
-        return new Frequency(timesNum, normalizedInterval, resolvedDuration);
+        return new Frequency(timesNum, resolvedInterval, resolvedDuration);
       }),
     );
   }
@@ -82,8 +84,7 @@ export class Frequency extends ValueObject implements IFrequency {
    * previously existing frequency payload.
    */
   public static createUnchecked({ interval, times, duration }: IFrequency) {
-    const normalizedInterval = this.normalizeInterval(interval);
-    return new Frequency(times, normalizedInterval, duration);
+    return new Frequency(times, interval, duration);
   }
 
   private static ensurePositiveInteger(value: number, label: string) {

--- a/src/modules/therapeutic-journey/aggregates/activity.aggregate.ts
+++ b/src/modules/therapeutic-journey/aggregates/activity.aggregate.ts
@@ -1,0 +1,49 @@
+import { AggregateRoot } from "@/common/entities/aggregate-root";
+import type { Frequency } from "@/common/time/value-objects/frequency.vo";
+import { generateUUID, type UUID } from "@/common/uuid";
+
+type ActivityProps = {
+  id: UUID;
+  title: string;
+  frequency: Frequency;
+  assigneeProfessionalId: UUID;
+  documentsIds: UUID[];
+  state: Activity.State;
+  createdAt: Date;
+};
+
+type CreateNewActivityParams = {
+  title: string;
+  frequency: Frequency;
+  assigneeProfessionalId: UUID;
+  documentsIds?: UUID[];
+};
+
+export class Activity extends AggregateRoot<ActivityProps> {
+  public static create({ documentsIds = [], ...props }: CreateNewActivityParams) {
+    return new this({
+      ...props,
+      documentsIds,
+      state: Activity.State.Suggested,
+      id: generateUUID(),
+      createdAt: new Date(),
+    });
+  }
+
+  /**
+   * Rehydratates an activity, i.e., creates a new `Activity` instance from a previously
+   * existing activity.
+   */
+  public static createUnchecked(props: ActivityProps) {
+    return new this(props);
+  }
+}
+
+export namespace Activity {
+  export enum State {
+    Suggested = "suggested",
+    Rejected = "rejected",
+    Running = "running",
+    Archived = "archived",
+  }
+}

--- a/src/modules/therapeutic-journey/aggregates/activity.aggregate.ts
+++ b/src/modules/therapeutic-journey/aggregates/activity.aggregate.ts
@@ -37,6 +37,10 @@ export class Activity extends AggregateRoot<ActivityProps> {
   public static createUnchecked(props: ActivityProps) {
     return new this(props);
   }
+
+  public equals(other: AggregateRoot<ActivityProps>) {
+    return other instanceof Activity && this._props.id === other._props.id;
+  }
 }
 
 export namespace Activity {

--- a/src/modules/therapeutic-journey/aggregates/document.aggregate.ts
+++ b/src/modules/therapeutic-journey/aggregates/document.aggregate.ts
@@ -1,0 +1,46 @@
+import { AggregateRoot } from "@/common/entities/aggregate-root";
+import { generateUUID, type UUID } from "@/common/uuid";
+
+type DocumentProps = {
+  id: UUID;
+  patientId: UUID;
+  title: string;
+  description?: string;
+  documentUrl: URL;
+  createdAt: Date;
+  lastUpdatedAt?: Date;
+};
+
+type CreateNewDocumentParams = {
+  title: string;
+  description?: string;
+  documentUrl: URL;
+  patientId: UUID;
+};
+
+/**
+ * A document from the patient of id `patientId`. Multiples `Document`s composes the patient's
+ * _Prontuário_ (medical record).
+ */
+export class Document extends AggregateRoot<DocumentProps> {
+  public static create(props: CreateNewDocumentParams) {
+    return new this({
+      ...props,
+      id: generateUUID(),
+      createdAt: new Date(),
+      lastUpdatedAt: undefined,
+    });
+  }
+
+  public static createUnchecked(props: DocumentProps) {
+    return new this(props);
+  }
+
+  public equals(other: Document): boolean {
+    return other instanceof this.constructor && this._props.id === other._props.id;
+  }
+
+  private touch() {
+    this._props.lastUpdatedAt = new Date();
+  }
+}

--- a/src/modules/therapeutic-journey/aggregates/pts.aggregate.ts
+++ b/src/modules/therapeutic-journey/aggregates/pts.aggregate.ts
@@ -1,8 +1,9 @@
 import { AggregateRoot } from "@/common/entities/aggregate-root";
-import { type UUID } from "@/common/uuid";
+import { generateUUID, type UUID } from "@/common/uuid";
 import { PtsTimeline } from "@/modules/therapeutic-journey/value-objects/pts-timeline.vo";
 
 type PtsProps = {
+  id: UUID;
   /**
    * The identifier of the patient whom this PTS belongs to.
    */
@@ -37,6 +38,7 @@ export class ProjetoTerapeuticoSingular extends AggregateRoot<PtsProps> {
     responsibleProfessionalId,
   }: CreateNewPtsParams) {
     return new this({
+      id: generateUUID(),
       patientId,
       socialSituation,
       responsibleProfessionalId,
@@ -88,5 +90,9 @@ export class ProjetoTerapeuticoSingular extends AggregateRoot<PtsProps> {
     ];
 
     return terminalStates.includes(currentState);
+  }
+
+  public equals(other: AggregateRoot<PtsProps>) {
+    return other instanceof ProjetoTerapeuticoSingular && this._props.id === other._props.id;
   }
 }

--- a/src/modules/therapeutic-journey/aggregates/pts.aggregate.ts
+++ b/src/modules/therapeutic-journey/aggregates/pts.aggregate.ts
@@ -1,0 +1,92 @@
+import { AggregateRoot } from "@/common/entities/aggregate-root";
+import { type UUID } from "@/common/uuid";
+import { PtsTimeline } from "@/modules/therapeutic-journey/value-objects/pts-timeline.vo";
+
+type PtsProps = {
+  /**
+   * The identifier of the patient whom this PTS belongs to.
+   */
+  patientId: UUID;
+  /**
+   * The identifier of the professional (profile) leading this PTS.
+   */
+  responsibleProfessionalId: UUID;
+  /**
+   * The identifiers of every professional (profile) involved with this PTS.
+   */
+  multidisciplinaryTeamIds: UUID[];
+  /**
+   * A text containing info about the patient (identified by `patientId`) regarding their social
+   * situation. E.g., who they live with, whether they have support network (and who they are),
+   * social vulnerability they're under, their desires and goals, _et cetera_.
+   */
+  socialSituation: string;
+  timeline: PtsTimeline;
+};
+
+type CreateNewPtsParams = {
+  patientId: UUID;
+  responsibleProfessionalId: UUID;
+  socialSituation: string;
+};
+
+export class ProjetoTerapeuticoSingular extends AggregateRoot<PtsProps> {
+  public static create({
+    patientId,
+    socialSituation,
+    responsibleProfessionalId,
+  }: CreateNewPtsParams) {
+    return new this({
+      patientId,
+      socialSituation,
+      responsibleProfessionalId,
+      timeline: PtsTimeline.create(),
+      multidisciplinaryTeamIds: [],
+    });
+  }
+
+  /**
+   * Rehydrates a PTS instance, i.e., creates a PTS from an existing PTS.
+   *
+   * @note This method does not perform any check nor provide any default value. Only use
+   * it to get a PTS instance for some already existing PTS.
+   */
+  public static createUnchecked(props: PtsProps) {
+    return new this(props);
+  }
+
+  public isDraft() {
+    return this._props.timeline.status === PtsTimeline.Status.Draft;
+  }
+
+  public isRejected() {
+    return this._props.timeline.status === PtsTimeline.Status.Rejected;
+  }
+
+  public isPlanning() {
+    return this._props.timeline.status === PtsTimeline.Status.Planning;
+  }
+
+  public isRunning() {
+    return this._props.timeline.status === PtsTimeline.Status.Running;
+  }
+
+  public isCancelled() {
+    return this._props.timeline.status === PtsTimeline.Status.Cancelled;
+  }
+
+  public isConcluded() {
+    return this._props.timeline.status === PtsTimeline.Status.Concluded;
+  }
+
+  public isTerminated() {
+    const currentState = this._props.timeline.status;
+    const terminalStates = [
+      PtsTimeline.Status.Cancelled,
+      PtsTimeline.Status.Rejected,
+      PtsTimeline.Status.Concluded,
+    ];
+
+    return terminalStates.includes(currentState);
+  }
+}

--- a/src/modules/therapeutic-journey/aggregates/therapeutic-journey.entity.ts
+++ b/src/modules/therapeutic-journey/aggregates/therapeutic-journey.entity.ts
@@ -1,9 +1,0 @@
-import { AggregateRoot } from "@/common/entities/aggregate-root";
-import { type UUID } from "@/common/uuid";
-
-type TherapeuticJourneyProps = {
-  responsibleProfessionalId: UUID;
-  multidisciplinaryTeamIds: UUID[];
-};
-
-export class TherapeuticJourney extends AggregateRoot<TherapeuticJourneyProps> {}

--- a/src/modules/therapeutic-journey/errors/status-integrity-violation.error.ts
+++ b/src/modules/therapeutic-journey/errors/status-integrity-violation.error.ts
@@ -1,0 +1,3 @@
+import { BadRequestError } from "@/common/errors/bad-request.error";
+
+export class StatusIntegrityViolationError extends BadRequestError {}

--- a/src/modules/therapeutic-journey/value-objects/pts-timeline.vo.ts
+++ b/src/modules/therapeutic-journey/value-objects/pts-timeline.vo.ts
@@ -1,0 +1,167 @@
+import { StatusIntegrityViolationError } from "@/modules/therapeutic-journey/errors/status-integrity-violation.error";
+import { either as e } from "fp-ts";
+
+interface IPtsTimeline {
+  readonly status: PtsTimeline.Status;
+  readonly createdAt: Date;
+  /**
+   * The date-time when the patient (identified by `patientId`) accepted this PTS.
+   */
+  readonly acceptedAt?: Date;
+  /**
+   * The date-time when the patient (identified by `patientId`) denied this PTS.
+   */
+  readonly rejectedAt?: Date;
+  /**
+   * The date-time when the planning ended and the PTS took action.
+   */
+  readonly beganAt?: Date;
+  /**
+   * The date-time when the PTS has been finished (the patient's been discharged).
+   */
+  readonly concludedAt?: Date;
+  /**
+   * The date-time when the PTS has been cancelled. E.g., the patient changed to a brand new PTS.
+   */
+  readonly cancelledAt?: Date;
+}
+
+export class PtsTimeline implements IPtsTimeline {
+  public readonly status: PtsTimeline.Status;
+  public readonly createdAt: Date;
+  public readonly acceptedAt?: Date;
+  public readonly rejectedAt?: Date;
+  public readonly beganAt?: Date;
+  public readonly concludedAt?: Date;
+  public readonly cancelledAt?: Date;
+
+  private constructor(props: IPtsTimeline) {
+    this.status = props.status;
+    this.createdAt = props.createdAt;
+    this.acceptedAt = props.acceptedAt;
+    this.rejectedAt = props.rejectedAt;
+    this.beganAt = props.beganAt;
+    this.concludedAt = props.concludedAt;
+    this.cancelledAt = props.cancelledAt;
+  }
+
+  public static create() {
+    return new PtsTimeline({
+      status: PtsTimeline.Status.Draft,
+      createdAt: new Date(),
+    });
+  }
+
+  public static createUnchecked(status: IPtsTimeline) {
+    return new PtsTimeline(status);
+  }
+
+  public acceptAndBeginPlanning() {
+    if (this.status === PtsTimeline.Status.Planning) return e.right(this);
+
+    if (this.status !== PtsTimeline.Status.Draft) {
+      const message = "Você não pode iniciar o planejamento um PTS que não é mais um rascunho.";
+      return e.left(new StatusIntegrityViolationError({ message }));
+    }
+
+    const newStatus = new PtsTimeline({
+      status: PtsTimeline.Status.Planning,
+      createdAt: this.createdAt,
+      acceptedAt: new Date(),
+    });
+
+    return e.right(newStatus);
+  }
+
+  public reject() {
+    if (this.status === PtsTimeline.Status.Rejected) return e.right(this);
+
+    if (this.status !== PtsTimeline.Status.Draft) {
+      const message = "Você só pode rejeitar a proposta de um PTS quando ele ainda é um rascunho.";
+      return e.left(new StatusIntegrityViolationError({ message }));
+    }
+
+    const newStatus = new PtsTimeline({
+      ...this,
+      status: PtsTimeline.Status.Rejected,
+      rejectedAt: new Date(),
+    });
+
+    return e.right(newStatus);
+  }
+
+  public begin() {
+    if (this.status === PtsTimeline.Status.Running) return e.right(this);
+
+    if (this.status !== PtsTimeline.Status.Planning) {
+      const message =
+        "O PTS precisa estar atualmente em fase de planejamento " +
+        "para que possa ser, enfim, iniciado.";
+
+      return e.left(new StatusIntegrityViolationError({ message }));
+    }
+
+    const newStatus = new PtsTimeline({
+      ...this,
+      status: PtsTimeline.Status.Running,
+      beganAt: new Date(),
+    });
+
+    return e.right(newStatus);
+  }
+
+  public conclude() {
+    if (this.status === PtsTimeline.Status.Concluded) return e.right(this);
+
+    if (this.status === PtsTimeline.Status.Cancelled) {
+      const message = "Você não pode concluir um PTS que foi cancelado.";
+      return e.left(new StatusIntegrityViolationError({ message }));
+    }
+
+    if (this.status === PtsTimeline.Status.Rejected) {
+      const message = "Você não pode concluir um PTS que foi rejeitado.";
+      return e.left(new StatusIntegrityViolationError({ message }));
+    }
+
+    if (this.status !== PtsTimeline.Status.Running) {
+      const message = "Você só pode concluir um PTS que esteja em andamento (até então).";
+      return e.left(new StatusIntegrityViolationError({ message }));
+    }
+
+    const newStatus = new PtsTimeline({
+      ...this,
+      status: PtsTimeline.Status.Concluded,
+      concludedAt: new Date(),
+    });
+
+    return e.right(newStatus);
+  }
+
+  public cancel() {
+    if (this.status === PtsTimeline.Status.Cancelled) return e.right(this);
+
+    if ([PtsTimeline.Status.Concluded, PtsTimeline.Status.Rejected].includes(this.status)) {
+      const message = "Você não pode cancelar um PTS que não está mais em andamento.";
+      return e.left(new StatusIntegrityViolationError({ message }));
+    }
+
+    const newStatus = new PtsTimeline({
+      ...this,
+      status: PtsTimeline.Status.Cancelled,
+      cancelledAt: new Date(),
+    });
+
+    return e.right(newStatus);
+  }
+}
+
+export namespace PtsTimeline {
+  export enum Status {
+    Draft = "draft",
+    Planning = "planning",
+    Running = "running",
+    Concluded = "concluded",
+    Cancelled = "cancelled",
+    Rejected = "rejected",
+  }
+}

--- a/src/modules/therapeutic-journey/value-objects/pts-timeline.vo.ts
+++ b/src/modules/therapeutic-journey/value-objects/pts-timeline.vo.ts
@@ -156,6 +156,11 @@ export class PtsTimeline implements IPtsTimeline {
 }
 
 export namespace PtsTimeline {
+  // We keep this encapsulated in such manner in order to avoid ourselves
+  // using this status directly, bypassing the timeline's rules.
+  // It can still be accessed, but will require so many dots that will be
+  // discouraging!
+
   export enum Status {
     Draft = "draft",
     Planning = "planning",


### PR DESCRIPTION
Esse PR introduz as entidades `Activity`, `Document` e `ProjetoTerapeuticoSingular`, bem como adiciona seus modelos (e dos seus _value objects_) no _schema_ do banco de dados.

## Outras adições
- _Value object_ `Frequency`.
- _Value object_ `PtsTimeline`.
- Novos erros `StatusIntegrityViolationError` e `FrequencyIntegrityViolationError`.

## Correções
- Corrigida a implementação padrão do `equal` da classe `ValueObject`.

## Mudanças
- `AggregateRoot` agora exige uma implementação explicita de `equals`.
- `TherapeuticJourney` foi renomeada para `ProjetoTerapeuticoSingular` a fim de resolver a ambiguidade que o primeiro nome causa.

Esse PR fecha #62.