### PR TITLE
feat: adiciona endpoint para criação de PTSs (em estado 'draft')

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import datastoreConfig from "@/configs/datastore.config";
 import { AuthModule } from "@/infra/auth/auth.module";
 import appConfig from "@/configs/app.config";
 import keysetConfig from "@/configs/keyset.config";
+import { TherapeuticJourneyModule } from "@/modules/therapeutic-journey/therapeutic-journey.module";
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import keysetConfig from "@/configs/keyset.config";
     PrismaModule,
     IdentityModule,
     AuthModule,
+    TherapeuticJourneyModule,
   ],
 })
 export class AppModule {}

--- a/src/common/errors/forbidden.error.ts
+++ b/src/common/errors/forbidden.error.ts
@@ -1,0 +1,16 @@
+import { BaseError, IBaseError } from "./base.error";
+
+interface IforbiddenError {
+  message?: string;
+}
+
+const defaultMessage = "Você não tem permissão.";
+
+export class ForbiddenError extends BaseError implements IforbiddenError {
+  public readonly message: string;
+
+  public constructor({ message = defaultMessage }: IforbiddenError = {}, options: IBaseError = {}) {
+    super(options);
+    this.message = message;
+  }
+}

--- a/src/infra/auth/decorators/current-user.ts
+++ b/src/infra/auth/decorators/current-user.ts
@@ -1,0 +1,11 @@
+import { JwtPayload } from "@/infra/auth/jwt/payload";
+import { ExecutionContext, createParamDecorator } from "@nestjs/common";
+
+export const CurrentUser = createParamDecorator((_factory, context: ExecutionContext) => {
+  const request = context.switchToHttp().getRequest();
+
+  const thereIsNoUser = Object.keys(request.user ?? {}).length === 0;
+  if (thereIsNoUser) return null;
+
+  return thereIsNoUser ? null : (request.user as JwtPayload);
+});

--- a/src/infra/auth/decorators/current-user.ts
+++ b/src/infra/auth/decorators/current-user.ts
@@ -1,4 +1,4 @@
-import { JwtPayload } from "@/infra/auth/jwt/payload";
+import { AuthCollection } from "@/infra/auth/auth-collection";
 import { ExecutionContext, createParamDecorator } from "@nestjs/common";
 
 export const CurrentUser = createParamDecorator((_factory, context: ExecutionContext) => {
@@ -7,5 +7,5 @@ export const CurrentUser = createParamDecorator((_factory, context: ExecutionCon
   const thereIsNoUser = Object.keys(request.user ?? {}).length === 0;
   if (thereIsNoUser) return null;
 
-  return thereIsNoUser ? null : (request.user as JwtPayload);
+  return thereIsNoUser ? null : (request.user as AuthCollection);
 });

--- a/src/infra/http/exceptions/exceptions-factory.ts
+++ b/src/infra/http/exceptions/exceptions-factory.ts
@@ -1,6 +1,7 @@
 import { BadRequestError } from "@/common/errors/bad-request.error";
 import { BaseError } from "@/common/errors/base.error";
 import { ConflictError } from "@/common/errors/conflict.error";
+import { ForbiddenError } from "@/common/errors/forbidden.error";
 import { InvalidArgumentError } from "@/common/errors/invalid-argument.error";
 import { IrrecoverableError } from "@/common/errors/irrecoverable.error";
 import { ResourceNotFoundError } from "@/common/errors/resource-not-found.error";
@@ -11,6 +12,7 @@ import { ValidationErrorsBagException } from "@/infra/http/exceptions/validation
 import {
   BadRequestException,
   ConflictException,
+  ForbiddenException,
   InternalServerErrorException,
   NotFoundException,
   UnauthorizedException,
@@ -24,6 +26,11 @@ function fromError(error: BaseError | ValidationErrorsBag): never {
   if (error instanceof UnauthorizedError) {
     const { cause } = error;
     throw new UnauthorizedException(BasicExceptionPresenter.present(error), { cause });
+  }
+
+  if (error instanceof ForbiddenError) {
+    const { cause } = error;
+    throw new ForbiddenException(BasicExceptionPresenter.present(error), { cause });
   }
 
   if (error instanceof InvalidArgumentError) {

--- a/src/infra/prisma/foreign-keys.ts
+++ b/src/infra/prisma/foreign-keys.ts
@@ -1,0 +1,14 @@
+export enum PrismaSchemaForeignKey {
+  // Lat updated: Migration 3 - 20260424052424_add_professionals_patient_accounts_and_basic_therapeutic_journey/migration.sql
+  PatientAccountId = "patient_accountId_fkey",
+  ProfessionalAccountId = "professional_accountId_fkey",
+  ProfessionalMembershipOnPtsProfessionalId = "professional_participating_on_therapeutic_journey_professi_fkey",
+  ProfessionalMembershipOnPtsPtsId = "professional_participating_on_therapeutic_journey_therapeu_fkey",
+  PtsResponsibleProfessionalId = "projeto_terapeutico_singular_responsible_professional_id_fkey",
+  PtsPatientId = "projeto_terapeutico_singular_patient_id_fkey",
+  DocumentPatientAccountId = "document_patient_account_id_fkey",
+  ActivityReferringToDocumentActivityId = "activity_referring_to_document_rel_activity_id_fkey",
+  ActivityReferringToDocumentDocumentId = "activity_referring_to_document_rel_document_id_fkey",
+  ActivityAssigneeProfessionalId = "activity_assignee_professional_id_fkey",
+  ActivityPtsId = "activity_projeto_terapeutico_singular_id_fkey",
+}

--- a/src/infra/prisma/mappers/pts.mapper.ts
+++ b/src/infra/prisma/mappers/pts.mapper.ts
@@ -40,6 +40,10 @@ function intoPrisma(
   pts: ProjetoTerapeuticoSingular,
 ): Prisma.ProjetoTerapeuticoSingularCreateArgs["data"] {
   const snapshot = pts.toSnapshot();
+  const multidisciplinaryTeam = snapshot.multidisciplinaryTeamIds.map((id) => ({
+    professionalId: id.toString(),
+  }));
+
   return {
     socialSituation: snapshot.socialSituation,
     status: statusIntoPrisma(snapshot.timeline.status),
@@ -52,6 +56,7 @@ function intoPrisma(
     id: snapshot.id.toString(),
     patientId: snapshot.patientId.toString(),
     responsibleProfessionalId: snapshot.responsibleProfessionalId.toString(),
+    multidisciplinaryTeam: { createMany: { data: multidisciplinaryTeam } },
   };
 }
 

--- a/src/infra/prisma/mappers/pts.mapper.ts
+++ b/src/infra/prisma/mappers/pts.mapper.ts
@@ -56,11 +56,17 @@ function intoPrisma(
 }
 
 function fromPrisma(
-  raw: Prisma.ProjetoTerapeuticoSingularModel & { multidisciplinaryTeamIds: string[] },
+  raw: Prisma.ProjetoTerapeuticoSingularModel & {
+    multidisciplinaryTeam: {
+      professionalId: string;
+    }[];
+  },
 ): ProjetoTerapeuticoSingular {
   return ProjetoTerapeuticoSingular.createUnchecked({
     id: raw.id,
-    multidisciplinaryTeamIds: raw.multidisciplinaryTeamIds,
+    multidisciplinaryTeamIds: raw.multidisciplinaryTeam.map(
+      (professional) => professional.professionalId,
+    ),
     patientId: raw.patientId,
     responsibleProfessionalId: raw.responsibleProfessionalId,
     socialSituation: raw.socialSituation,

--- a/src/infra/prisma/prisma.module.ts
+++ b/src/infra/prisma/prisma.module.ts
@@ -4,6 +4,8 @@ import { AccountsRepository } from "@/modules/identity/repositories/accounts.rep
 import { PrismaAccountsRepository } from "@/infra/prisma/repositories/accounts.repository";
 import { ProfessionalsRepository } from "@/modules/professional/professionals.repository";
 import { PrismaProfessionalsRepository } from "@/infra/prisma/repositories/professionals.repository";
+import { PtsRepository } from "@/modules/therapeutic-journey/repositories/pts.repository";
+import { PrismaPtsRepository } from "@/infra/prisma/repositories/pts.repository";
 
 @Global()
 @Module({
@@ -11,7 +13,8 @@ import { PrismaProfessionalsRepository } from "@/infra/prisma/repositories/profe
     PrismaService,
     { provide: AccountsRepository, useClass: PrismaAccountsRepository },
     { provide: ProfessionalsRepository, useClass: PrismaProfessionalsRepository },
+    { provide: PtsRepository, useClass: PrismaPtsRepository },
   ],
-  exports: [PrismaService, AccountsRepository, ProfessionalsRepository],
+  exports: [PrismaService, AccountsRepository, ProfessionalsRepository, PtsRepository],
 })
 export class PrismaModule {}

--- a/src/infra/prisma/repositories/accounts-repository.int-spec.ts
+++ b/src/infra/prisma/repositories/accounts-repository.int-spec.ts
@@ -29,7 +29,9 @@ describe("[Integration] Prisma Accounts Repository", () => {
 
     accountRepo = app.get(AccountsRepository);
     sut = app.get(CreateAccountService);
+  });
 
+  beforeEach(async () => {
     const account = await accountsFactory.create(
       { email: knownEmail },
       { hasher: hasherAndComparator },

--- a/src/infra/prisma/repositories/pts-repository.int-spec.ts
+++ b/src/infra/prisma/repositories/pts-repository.int-spec.ts
@@ -1,0 +1,109 @@
+import { AppModule } from "@/app.module";
+import type { INestApplication } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+import { App } from "supertest/types";
+import patientsFactory from "@test/factories/patients.factory";
+import { Patient } from "@/modules/patient/entities/patient.entity";
+import { PrismaService } from "@/infra/prisma/prisma";
+import ptsFactory from "@test/factories/pts.factory";
+import { PtsTimeline } from "@/modules/therapeutic-journey/value-objects/pts-timeline.vo";
+import { PrismaPtsRepository } from "@/infra/prisma/repositories/pts.repository";
+import { either } from "fp-ts";
+
+describe("[Integration] Prisma PTS Repository", () => {
+  let prisma: PrismaService;
+  let patient: Patient;
+
+  // repository under test
+  let rut: PrismaPtsRepository;
+
+  beforeAll(async () => {
+    let app: INestApplication<App>;
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+      providers: [PrismaPtsRepository],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+
+    prisma = app.get(PrismaService);
+    rut = app.get(PrismaPtsRepository);
+
+    await app.init();
+  });
+
+  beforeEach(async () => {
+    patient = await patientsFactory.createAndPersist(prisma);
+  });
+
+  describe("", async () => {
+    it.each([
+      ptsFactory.createTimeline({ status: PtsTimeline.Status.Planning }),
+      ptsFactory.createTimeline({ status: PtsTimeline.Status.Running }),
+    ])(
+      "should return truthy when there is a PTS in in active ($status) state",
+      { tags: ["activePtsExistsByPatientId"] },
+      async (timeline) => {
+        await ptsFactory.createAndPersist(prisma, { timeline, patientId: patient.getId() });
+        const result = await rut.activePtsExistsByPatientId(patient.getId());
+
+        assert(either.isRight(result), "it should have counted successfully");
+
+        expect(
+          result.right,
+          "it should have accused there is an active PTS for given patient",
+        ).toBe(true);
+      },
+    );
+
+    it.each([
+      ptsFactory.createTimeline({ status: PtsTimeline.Status.Cancelled, cancelledAt: new Date() }),
+      ptsFactory.createTimeline({ status: PtsTimeline.Status.Concluded, concludedAt: new Date() }),
+      ptsFactory.createTimeline({ status: PtsTimeline.Status.Draft, createdAt: new Date() }),
+      ptsFactory.createTimeline({ status: PtsTimeline.Status.Rejected, rejectedAt: new Date() }),
+    ])(
+      "should return falsy if there is one PTS but with the non-active $status state",
+      { tags: ["activePtsExistsByPatientId"] },
+      async (timeline) => {
+        await ptsFactory.createAndPersist(prisma, { timeline, patientId: patient.getId() });
+
+        const result = await rut.activePtsExistsByPatientId(patient.getId());
+
+        assert(either.isRight(result), "it should have counted successfully");
+        expect(result.right).toBe(false);
+      },
+    );
+
+    it(
+      "should return falsy if there are many PTSs but with any non-active ($status) state",
+      { tags: ["activePtsExistsByPatientId"] },
+      async () => {
+        const nonActiveStates = [
+          ptsFactory.createTimeline({
+            status: PtsTimeline.Status.Cancelled,
+            cancelledAt: new Date(),
+          }),
+          ptsFactory.createTimeline({
+            status: PtsTimeline.Status.Concluded,
+            concludedAt: new Date(),
+          }),
+          ptsFactory.createTimeline({ status: PtsTimeline.Status.Draft, createdAt: new Date() }),
+          ptsFactory.createTimeline({
+            status: PtsTimeline.Status.Rejected,
+            rejectedAt: new Date(),
+          }),
+        ];
+
+        for (const timeline of nonActiveStates) {
+          await ptsFactory.createAndPersist(prisma, { timeline, patientId: patient.getId() });
+        }
+
+        const result = await rut.activePtsExistsByPatientId(patient.getId());
+
+        assert(either.isRight(result), "it should have counted successfully");
+        expect(result.right).toBe(false);
+      },
+    );
+  });
+});

--- a/src/infra/prisma/repositories/pts.repository.ts
+++ b/src/infra/prisma/repositories/pts.repository.ts
@@ -18,7 +18,6 @@ export class PrismaPtsRepository extends PtsRepository {
     super();
   }
 
-  // TODO: add integration tests to this method
   public activePtsExistsByPatientId(patientId: UUID): Promise<Either<IrrecoverableError, boolean>> {
     return pipe(
       te.tryCatch(

--- a/src/infra/prisma/repositories/pts.repository.ts
+++ b/src/infra/prisma/repositories/pts.repository.ts
@@ -23,7 +23,7 @@ export class PrismaPtsRepository extends PtsRepository {
           this.prisma.projetoTerapeuticoSingular.count({
             where: {
               patientId: patientId.toString(),
-              AND: { status: { in: ["Running", "Planning"] } },
+              status: { in: ["Running", "Planning"] },
             },
           }),
         (error) =>

--- a/src/infra/prisma/repositories/pts.repository.ts
+++ b/src/infra/prisma/repositories/pts.repository.ts
@@ -1,10 +1,13 @@
 import { IrrecoverableError } from "@/common/errors/irrecoverable.error";
 import { UUID } from "@/common/uuid";
+import ptsMapper from "@/infra/prisma/mappers/pts.mapper";
 import { PrismaService } from "@/infra/prisma/prisma";
 import { ProjetoTerapeuticoSingular } from "@/modules/therapeutic-journey/aggregates/pts.aggregate";
 import { PtsRepository } from "@/modules/therapeutic-journey/repositories/pts.repository";
 import { Injectable } from "@nestjs/common";
+import { taskEither as te } from "fp-ts";
 import { Either } from "fp-ts/lib/Either";
+import { pipe } from "fp-ts/lib/function";
 
 @Injectable()
 export class PrismaPtsRepository extends PtsRepository {
@@ -12,13 +15,46 @@ export class PrismaPtsRepository extends PtsRepository {
     super();
   }
 
+  // TODO: add integration tests to this method
   public activePtsExistsByPatientId(patientId: UUID): Promise<Either<IrrecoverableError, boolean>> {
-    throw new Error("Method not implemented.");
+    return pipe(
+      te.tryCatch(
+        () =>
+          this.prisma.projetoTerapeuticoSingular.count({
+            where: {
+              patientId: patientId.toString(),
+              AND: { status: { in: ["Running", "Planning"] } },
+            },
+          }),
+        (error) =>
+          new IrrecoverableError({
+            message: `Error occurred in ${PrismaPtsRepository.name} when trying to count active PTS from patient of ID '${patientId}'.`,
+            cause: error as Error,
+          }),
+      ),
+      te.map((count) => count !== 0),
+    )();
   }
 
   public createNewPts(
     pts: ProjetoTerapeuticoSingular,
   ): Promise<Either<IrrecoverableError, ProjetoTerapeuticoSingular>> {
-    throw new Error("Method not implemented.");
+    const payload = ptsMapper.intoPrisma(pts);
+
+    return pipe(
+      te.tryCatch(
+        () =>
+          this.prisma.projetoTerapeuticoSingular.create({
+            data: payload,
+            include: { multidisciplinaryTeam: { select: { professionalId: true } } },
+          }),
+        (error) =>
+          new IrrecoverableError({
+            message: `Error occurred in ${PrismaPtsRepository.name} when creating the PTS '${JSON.stringify(payload)}'.`,
+            cause: error as Error,
+          }),
+      ),
+      te.map(ptsMapper.fromPrisma),
+    )();
   }
 }

--- a/src/infra/prisma/repositories/pts.repository.ts
+++ b/src/infra/prisma/repositories/pts.repository.ts
@@ -1,0 +1,24 @@
+import { IrrecoverableError } from "@/common/errors/irrecoverable.error";
+import { UUID } from "@/common/uuid";
+import { PrismaService } from "@/infra/prisma/prisma";
+import { ProjetoTerapeuticoSingular } from "@/modules/therapeutic-journey/aggregates/pts.aggregate";
+import { PtsRepository } from "@/modules/therapeutic-journey/repositories/pts.repository";
+import { Injectable } from "@nestjs/common";
+import { Either } from "fp-ts/lib/Either";
+
+@Injectable()
+export class PrismaPtsRepository extends PtsRepository {
+  public constructor(private readonly prisma: PrismaService) {
+    super();
+  }
+
+  public activePtsExistsByPatientId(patientId: UUID): Promise<Either<IrrecoverableError, boolean>> {
+    throw new Error("Method not implemented.");
+  }
+
+  public createNewPts(
+    pts: ProjetoTerapeuticoSingular,
+  ): Promise<Either<IrrecoverableError, ProjetoTerapeuticoSingular>> {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/src/infra/prisma/repositories/pts.repository.ts
+++ b/src/infra/prisma/repositories/pts.repository.ts
@@ -1,10 +1,13 @@
 import { IrrecoverableError } from "@/common/errors/irrecoverable.error";
 import { UUID } from "@/common/uuid";
+import { PrismaSchemaForeignKey } from "@/infra/prisma/foreign-keys";
 import ptsMapper from "@/infra/prisma/mappers/pts.mapper";
 import { PrismaService } from "@/infra/prisma/prisma";
 import { ProjetoTerapeuticoSingular } from "@/modules/therapeutic-journey/aggregates/pts.aggregate";
+import { ProfessionalIsNotRegistered } from "@/modules/therapeutic-journey/errors/professional-is-not-registered.error";
 import { PtsRepository } from "@/modules/therapeutic-journey/repositories/pts.repository";
 import { Injectable } from "@nestjs/common";
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/client";
 import { taskEither as te } from "fp-ts";
 import { Either } from "fp-ts/lib/Either";
 import { pipe } from "fp-ts/lib/function";
@@ -36,9 +39,7 @@ export class PrismaPtsRepository extends PtsRepository {
     )();
   }
 
-  public createNewPts(
-    pts: ProjetoTerapeuticoSingular,
-  ): Promise<Either<IrrecoverableError, ProjetoTerapeuticoSingular>> {
+  public createNewPts(pts: ProjetoTerapeuticoSingular) {
     const payload = ptsMapper.intoPrisma(pts);
 
     return pipe(
@@ -48,11 +49,43 @@ export class PrismaPtsRepository extends PtsRepository {
             data: payload,
             include: { multidisciplinaryTeam: { select: { professionalId: true } } },
           }),
-        (error) =>
-          new IrrecoverableError({
-            message: `Error occurred in ${PrismaPtsRepository.name} when creating the PTS '${JSON.stringify(payload)}'.`,
+        (error) => {
+          const isUnexistingProfessionalError =
+            error instanceof PrismaClientKnownRequestError && error.code === "P2003";
+
+          if (!isUnexistingProfessionalError) {
+            return new IrrecoverableError({
+              message: `Error occurred in ${PrismaPtsRepository.name} when creating the PTS '${JSON.stringify(payload)}'.`,
+              cause: error as Error,
+            });
+          }
+
+          const exceprtContainingConstraint: string =
+            error?.meta?.["driverAdapterError"]?.["cause"]?.constraint?.index ?? error.message;
+
+          const responsibleProfessionalDoesNotExist =
+            isUnexistingProfessionalError &&
+            exceprtContainingConstraint.includes(
+              PrismaSchemaForeignKey.PtsResponsibleProfessionalId,
+            );
+
+          if (responsibleProfessionalDoesNotExist)
+            return new ProfessionalIsNotRegistered("responsible");
+
+          const someProfessionalFromMultidisciplinaryTeamDoesNotExist =
+            isUnexistingProfessionalError &&
+            exceprtContainingConstraint.includes(
+              PrismaSchemaForeignKey.ProfessionalMembershipOnPtsProfessionalId,
+            );
+
+          if (someProfessionalFromMultidisciplinaryTeamDoesNotExist)
+            return new ProfessionalIsNotRegistered("team");
+
+          return new IrrecoverableError({
+            message: `Failed to catch foreign key violation error in ${PrismaPtsRepository.name} when creating the PTS '${JSON.stringify(payload)}'.`,
             cause: error as Error,
-          }),
+          });
+        },
       ),
       te.map(ptsMapper.fromPrisma),
     )();

--- a/src/modules/identity/sessions.e2e-spec.ts
+++ b/src/modules/identity/sessions.e2e-spec.ts
@@ -35,7 +35,9 @@ describe("[e2e] Sessions Controller (v1)", () => {
     await app.init();
     prisma = app.get(PrismaService);
     hasher = app.get(Hasher);
+  });
 
+  beforeEach(async () => {
     const passwordHash = await hasher.hash(password);
     account = await accountsFactory.createAndPersist(prisma, { passwordHash });
   });

--- a/src/modules/professional/entities/professional.aggregate.ts
+++ b/src/modules/professional/entities/professional.aggregate.ts
@@ -1,5 +1,6 @@
 import { AggregateRoot } from "@/common/entities/aggregate-root";
 import { generateUUID, type UUID } from "@/common/uuid";
+import { Account } from "@/modules/identity/entities/account.aggregate";
 
 type ProfessionalProps = {
   id: UUID;
@@ -26,6 +27,11 @@ export class Professional extends AggregateRoot<ProfessionalProps> {
 
   public getSpecialism() {
     return this._props.specialism;
+  }
+
+  public belongsToAccount(account: Account | UUID) {
+    const accountId = account instanceof Account ? account.getId() : account;
+    return this._props.accountId === accountId;
   }
 
   public equals(other: Professional): boolean {

--- a/src/modules/therapeutic-journey/controllers/pts.controller.ts
+++ b/src/modules/therapeutic-journey/controllers/pts.controller.ts
@@ -9,6 +9,7 @@ import { ProfessionalDoesNotBelongToUserAccountError } from "@/modules/therapeut
 import { CreateDraftPtsService } from "@/modules/therapeutic-journey/services/create-draft-pts.service";
 import { Body, Controller, ForbiddenException, HttpCode, HttpStatus, Post } from "@nestjs/common";
 import {
+  ApiBadRequestResponse,
   ApiBearerAuth,
   ApiConflictResponse,
   ApiCreatedResponse,
@@ -39,6 +40,11 @@ export class PtsController {
   @ApiConflictResponse({
     type: BasicExceptionPresenter,
     description: "The patient to which the PTS would be created already have an active PTS ATM.",
+  })
+  @ApiBadRequestResponse({
+    type: BasicExceptionPresenter,
+    description:
+      "Some professional involved in the request is actually not registered in the platform.",
   })
   public storeNewPts(@Body() body: CreatePtsDto, @CurrentUser() { account }: AuthCollection) {
     return pipe(

--- a/src/modules/therapeutic-journey/controllers/pts.controller.ts
+++ b/src/modules/therapeutic-journey/controllers/pts.controller.ts
@@ -1,0 +1,73 @@
+import { CurrentUser } from "@/infra/auth/decorators/current-user";
+import { JwtPayload } from "@/infra/auth/jwt/payload";
+import { BasicExceptionPresenter } from "@/infra/http/exceptions/basic.presenter";
+import exceptionsFactory from "@/infra/http/exceptions/exceptions-factory";
+import { ValidationErrorBagPresenter } from "@/infra/http/exceptions/validation/presenter";
+import { ProfessionalProfileNotFoundError } from "@/modules/professional/errors/professional-profile-not-found.error";
+import { CreatePtsDto } from "@/modules/therapeutic-journey/dtos/create-pts.dto";
+import { ProfessionalDoesNotBelongToUserAccountError } from "@/modules/therapeutic-journey/errors/professional-does-not-belong-to-user-account.error";
+import { CreateDraftPtsService } from "@/modules/therapeutic-journey/services/create-draft-pts.service";
+import { Body, Controller, ForbiddenException, HttpCode, HttpStatus, Post } from "@nestjs/common";
+import {
+  ApiBearerAuth,
+  ApiConflictResponse,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiUnprocessableEntityResponse,
+} from "@nestjs/swagger";
+import { taskEither as te } from "fp-ts";
+import { pipe } from "fp-ts/lib/function";
+
+@Controller("v1/pts")
+export class PtsController {
+  public constructor(private readonly createDraftPts: CreateDraftPtsService) {}
+
+  @Post("create")
+  @HttpCode(HttpStatus.CREATED)
+  @ApiBearerAuth()
+  @ApiCreatedResponse({
+    description: "PTS successfully drafted.",
+  })
+  @ApiForbiddenResponse({
+    type: BasicExceptionPresenter,
+    description: "The provided professional is not allowed to create a PTS.",
+  })
+  @ApiUnprocessableEntityResponse({
+    type: ValidationErrorBagPresenter,
+    description: "Some of the inputs contain validation errors.",
+  })
+  @ApiConflictResponse({
+    type: BasicExceptionPresenter,
+    description: "The patient to which the PTS would be created already have an active PTS ATM.",
+  })
+  public storeNewPts(@Body() body: CreatePtsDto, @CurrentUser() { sub }: JwtPayload) {
+    return pipe(
+      () =>
+        this.createDraftPts.execute({
+          accountId: sub,
+          professionalId: body.professionalId,
+          patientId: body.patientId,
+          socialSituation: body.socialSituation,
+          multidisciplinaryTeamIds: body.multidisciplinaryTeamIds,
+        }),
+      te.mapLeft((error) => {
+        // We obfuscate the reason why it cannot do it, since informing these could lead some malicious user
+        // to successfully creating a PTS when it shouldn't be able to
+        if (
+          error instanceof ProfessionalProfileNotFoundError ||
+          error instanceof ProfessionalDoesNotBelongToUserAccountError
+        ) {
+          throw new ForbiddenException(
+            BasicExceptionPresenter.present({
+              message: "Você não tem permissão para criar rascunhar um PTS.",
+            }),
+            { cause: error },
+          );
+        }
+
+        return error;
+      }),
+      te.getOrElse(exceptionsFactory.fromError),
+    );
+  }
+}

--- a/src/modules/therapeutic-journey/controllers/pts.controller.ts
+++ b/src/modules/therapeutic-journey/controllers/pts.controller.ts
@@ -1,5 +1,5 @@
+import { AuthCollection } from "@/infra/auth/auth-collection";
 import { CurrentUser } from "@/infra/auth/decorators/current-user";
-import { JwtPayload } from "@/infra/auth/jwt/payload";
 import { BasicExceptionPresenter } from "@/infra/http/exceptions/basic.presenter";
 import exceptionsFactory from "@/infra/http/exceptions/exceptions-factory";
 import { ValidationErrorBagPresenter } from "@/infra/http/exceptions/validation/presenter";
@@ -40,11 +40,11 @@ export class PtsController {
     type: BasicExceptionPresenter,
     description: "The patient to which the PTS would be created already have an active PTS ATM.",
   })
-  public storeNewPts(@Body() body: CreatePtsDto, @CurrentUser() { sub }: JwtPayload) {
+  public storeNewPts(@Body() body: CreatePtsDto, @CurrentUser() { account }: AuthCollection) {
     return pipe(
       () =>
         this.createDraftPts.execute({
-          accountId: sub,
+          accountId: account.getId(),
           professionalId: body.professionalId,
           patientId: body.patientId,
           socialSituation: body.socialSituation,
@@ -68,6 +68,6 @@ export class PtsController {
         return error;
       }),
       te.getOrElse(exceptionsFactory.fromError),
-    );
+    )();
   }
 }

--- a/src/modules/therapeutic-journey/controllers/pts.e2e-spec.ts
+++ b/src/modules/therapeutic-journey/controllers/pts.e2e-spec.ts
@@ -1,0 +1,256 @@
+import { AppModule } from "@/app.module";
+import { generateUUID } from "@/common/uuid";
+import { AssignTokenService } from "@/infra/auth/assign-token.service";
+import ptsMapper from "@/infra/prisma/mappers/pts.mapper";
+import { PrismaService } from "@/infra/prisma/prisma";
+import { Hasher } from "@/modules/crypto/hasher";
+import { Account } from "@/modules/identity/entities/account.aggregate";
+import { Patient } from "@/modules/patient/entities/patient.entity";
+import { Professional } from "@/modules/professional/entities/professional.aggregate";
+import { type INestApplication } from "@nestjs/common";
+import { Test, type TestingModule } from "@nestjs/testing";
+import accountsFactory from "@test/factories/accounts.factory";
+import patientsFactory from "@test/factories/patients.factory";
+import professionalsFactory from "@test/factories/professionals.factory";
+import ptsFactory from "@test/factories/pts.factory";
+import { either as e, either } from "fp-ts";
+import request from "supertest";
+import type { App } from "supertest/types";
+
+describe("[e2e] PTS Controller (v1)", () => {
+  let app: INestApplication<App>;
+  let prisma: PrismaService;
+  let hasher: Hasher;
+  let tokensService: AssignTokenService;
+
+  let account: Account;
+  let professional: Professional;
+  let patient: Patient;
+  let professionalAccountToken: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    prisma = app.get(PrismaService);
+    hasher = app.get(Hasher);
+    tokensService = app.get(AssignTokenService);
+  });
+
+  beforeEach(async () => {
+    account = await accountsFactory.createAndPersist(
+      prisma,
+      { plainPassword: "12345678" },
+      { hasher },
+    );
+
+    professional = await professionalsFactory.createAndPersist(prisma, {
+      accountId: account.getId(),
+    });
+
+    patient = await patientsFactory.createAndPersist(prisma);
+
+    const accessTokenResult = await tokensService.execute({ account });
+    assert(e.isRight(accessTokenResult));
+    professionalAccountToken = accessTokenResult.right.accessToken;
+
+    assert(
+      professional.getAccountId() === account.getId(),
+      "factory should correctly set the given account id",
+    );
+  });
+
+  const getValidParams = () => ({
+    professionalId: professional.getId(),
+    patientId: patient.getId(),
+    socialSituation: "Mora sozinho, sem suporte familiar.",
+    multidisciplinaryTeamIds: [],
+  });
+
+  const assertIsValidationErrorsBag = (response: request.Response) => {
+    expect(response.body, "response should be a validation bag object").toHaveProperty("errors");
+  };
+
+  test("create PTS route requires authentication", async () => {
+    await request(app.getHttpServer()).post("/v1/pts/create").send(getValidParams()).expect(401);
+  });
+
+  it.each([
+    [{ professionalId: undefined }, "professionalId"] as const,
+    [{ patientId: undefined }, "patientId"] as const,
+    [{ socialSituation: undefined }, "socialSituation"] as const,
+  ])("should return 422 when `$1` is missing", async (override, missingProperty) => {
+    const body = {
+      ...getValidParams(),
+      ...override,
+    };
+
+    const response = await request(app.getHttpServer())
+      .post("/v1/pts/create")
+      .set({ authorization: `Bearer ${professionalAccountToken}` })
+      .send(body)
+      .expect(422);
+
+    assertIsValidationErrorsBag(response);
+    expect(response.body.errors).toHaveProperty(missingProperty);
+  });
+
+  it("should return 403 when the professionalId does not belong to the authenticated account", async () => {
+    // a second account whose professional will NOT belong to the first account
+    const anotherAccount = await accountsFactory.createAndPersist(
+      prisma,
+      { plainPassword: "12345657" },
+      { hasher },
+    );
+
+    const anotherAccessTokenResult = await tokensService.execute({ account: anotherAccount });
+    assert(either.isRight(anotherAccessTokenResult));
+    const { accessToken } = anotherAccessTokenResult.right;
+
+    // the authenticated user is `anotherAccount`, but `professionalId` belongs to (first) `account`
+    // hence it should not get to create the PTS
+    const body = {
+      ...getValidParams(),
+      professionalId: professional.getId(),
+      accountId: anotherAccount.getId(),
+    };
+
+    const response = await request(app.getHttpServer())
+      .post("/v1/pts/create")
+      .set({ authorization: `Bearer ${accessToken}` })
+      .send(body)
+      .expect(403);
+
+    expect(response.body).toHaveProperty("message");
+  });
+
+  it("should return 403 when the professionalId does not exist at all", async () => {
+    // ensure the ID does not exist
+    const nonExistingProfessionalId = generateUUID();
+    prisma.professional.delete({ where: { id: nonExistingProfessionalId } });
+
+    const response = await request(app.getHttpServer())
+      .post("/v1/pts/create")
+      .set({ authorization: `Bearer ${professionalAccountToken}` })
+      .send({ ...getValidParams(), professionalId: nonExistingProfessionalId })
+      .expect(403);
+
+    expect(response.body).toHaveProperty("message");
+  });
+
+  it("should return 409 when the patient already has an active PTS", async () => {
+    // note that `getValidParams()` returns the same patient, professional and account
+    const params = getValidParams();
+
+    const pts = await ptsFactory.createAndPersist(prisma, params);
+    pts.acceptAndBeginPlanning();
+
+    await prisma.projetoTerapeuticoSingular.update({
+      data: ptsMapper.intoPrisma(pts),
+      where: { id: pts.getId().toString() },
+    });
+
+    // second creation for the same patient should fail due to conflict
+    const conflictResponse = await request(app.getHttpServer())
+      .post("/v1/pts/create")
+      .set({ authorization: `Bearer ${professionalAccountToken}` })
+      .send(params)
+      .expect(409);
+
+    expect(conflictResponse.body).toHaveProperty("message");
+  });
+
+  it("should draft a PTS successfully", async () => {
+    const newPatient = await patientsFactory.createAndPersist(prisma);
+
+    const existingPtsForNewPatientPriorToCreation = await prisma.projetoTerapeuticoSingular.count({
+      where: { patientId: newPatient.getId().toString() },
+    });
+
+    expect(
+      existingPtsForNewPatientPriorToCreation,
+      "there should be 0 PTS for the newly created patient",
+    ).toBe(0);
+
+    await request(app.getHttpServer())
+      .post("/v1/pts/create")
+      .set({ authorization: `Bearer ${professionalAccountToken}` })
+      .send({ ...getValidParams(), patientId: newPatient.getId() })
+      .expect(201);
+
+    const existingPtsForNewPatient = await prisma.projetoTerapeuticoSingular.count({
+      where: { patientId: newPatient.getId().toString() },
+    });
+
+    expect(existingPtsForNewPatient, "it should have created a new PTS for the patient").toBe(1);
+  });
+
+  it("should require every professional from the multidisciplinary team to exist", async () => {
+    const secondProfessionalNotPersisted = await professionalsFactory.create();
+
+    const body = {
+      ...getValidParams(),
+      multidisciplinaryTeamIds: [secondProfessionalNotPersisted.getId()],
+    };
+
+    await request(app.getHttpServer())
+      .post("/v1/pts/create")
+      .set({ authorization: `Bearer ${professionalAccountToken}` })
+      .send(body)
+      .expect(400);
+
+    const persistedPts = await prisma.projetoTerapeuticoSingular.count({
+      where: { patientId: patient.getId().toString() },
+    });
+
+    expect(persistedPts, "it should not have created the PTS").toBe(0);
+  });
+
+  it("should draft a PTS with multidisciplinary team members successfully", async () => {
+    const newPatient = await patientsFactory.createAndPersist(prisma);
+
+    const teamMember1 = await professionalsFactory.createAndPersist(prisma, {
+      accountId: account.getId(),
+    });
+
+    const teamMember2 = await professionalsFactory.createAndPersist(prisma, {
+      accountId: account.getId(),
+    });
+
+    const inputMembersIds = [teamMember1.getId(), teamMember2.getId()];
+    const body = {
+      ...getValidParams(),
+      patientId: newPatient.getId(),
+      multidisciplinaryTeamIds: inputMembersIds,
+    };
+
+    await request(app.getHttpServer())
+      .post("/v1/pts/create")
+      .set({ authorization: `Bearer ${professionalAccountToken}` })
+      .send(body)
+      .expect(201);
+
+    const newPts = await prisma.projetoTerapeuticoSingular.findFirstOrThrow({
+      where: { patientId: newPatient.getId().toString() },
+      include: { multidisciplinaryTeam: { select: { professionalId: true } } },
+    });
+
+    const membersInTheMultidisciplinaryTeamOfPts = newPts.multidisciplinaryTeam.map(
+      (team) => team.professionalId,
+    );
+
+    expect(
+      membersInTheMultidisciplinaryTeamOfPts,
+      "it should have put every input member in the initial multidisciplinary team",
+    ).toEqual(expect.arrayContaining(inputMembersIds));
+
+    expect(
+      membersInTheMultidisciplinaryTeamOfPts.length,
+      "it should not have added more members than requested",
+    ).toBe(inputMembersIds.length);
+  });
+});

--- a/src/modules/therapeutic-journey/controllers/pts.e2e-spec.ts
+++ b/src/modules/therapeutic-journey/controllers/pts.e2e-spec.ts
@@ -55,13 +55,11 @@ describe("[e2e] PTS Controller (v1)", () => {
     patient = await patientsFactory.createAndPersist(prisma);
 
     const accessTokenResult = await tokensService.execute({ account });
-    assert(e.isRight(accessTokenResult));
-    professionalAccountToken = accessTokenResult.right.accessToken;
+    if (e.isLeft(accessTokenResult)) {
+      throw new Error("Didn't issued an access token correctly for the test.");
+    }
 
-    assert(
-      professional.getAccountId() === account.getId(),
-      "factory should correctly set the given account id",
-    );
+    professionalAccountToken = accessTokenResult.right.accessToken;
   });
 
   const getValidParams = () => ({
@@ -75,7 +73,7 @@ describe("[e2e] PTS Controller (v1)", () => {
     expect(response.body, "response should be a validation bag object").toHaveProperty("errors");
   };
 
-  test("create PTS route requires authentication", async () => {
+  test("create PTS route requires authentication", { tags: ["storeNewPts"] }, async () => {
     await request(app.getHttpServer()).post("/v1/pts/create").send(getValidParams()).expect(401);
   });
 
@@ -83,88 +81,104 @@ describe("[e2e] PTS Controller (v1)", () => {
     [{ professionalId: undefined }, "professionalId"] as const,
     [{ patientId: undefined }, "patientId"] as const,
     [{ socialSituation: undefined }, "socialSituation"] as const,
-  ])("should return 422 when `$1` is missing", async (override, missingProperty) => {
-    const body = {
-      ...getValidParams(),
-      ...override,
-    };
+  ])(
+    "should return 422 when `$1` is missing",
+    { tags: ["storeNewPts"] },
+    async (override, missingProperty) => {
+      const body = {
+        ...getValidParams(),
+        ...override,
+      };
 
-    const response = await request(app.getHttpServer())
-      .post("/v1/pts/create")
-      .set({ authorization: `Bearer ${professionalAccountToken}` })
-      .send(body)
-      .expect(422);
+      const response = await request(app.getHttpServer())
+        .post("/v1/pts/create")
+        .set({ authorization: `Bearer ${professionalAccountToken}` })
+        .send(body)
+        .expect(422);
 
-    assertIsValidationErrorsBag(response);
-    expect(response.body.errors).toHaveProperty(missingProperty);
-  });
+      assertIsValidationErrorsBag(response);
+      expect(response.body.errors).toHaveProperty(missingProperty);
+    },
+  );
 
-  it("should return 403 when the professionalId does not belong to the authenticated account", async () => {
-    // a second account whose professional will NOT belong to the first account
-    const anotherAccount = await accountsFactory.createAndPersist(
-      prisma,
-      { plainPassword: "12345657" },
-      { hasher },
-    );
+  it(
+    "should return 403 when the professionalId does not belong to the authenticated account",
+    { tags: ["storeNewPts"] },
+    async () => {
+      // a second account whose professional will NOT belong to the first account
+      const anotherAccount = await accountsFactory.createAndPersist(
+        prisma,
+        { plainPassword: "12345657" },
+        { hasher },
+      );
 
-    const anotherAccessTokenResult = await tokensService.execute({ account: anotherAccount });
-    assert(either.isRight(anotherAccessTokenResult));
-    const { accessToken } = anotherAccessTokenResult.right;
+      const anotherAccessTokenResult = await tokensService.execute({ account: anotherAccount });
+      assert(either.isRight(anotherAccessTokenResult));
+      const { accessToken } = anotherAccessTokenResult.right;
 
-    // the authenticated user is `anotherAccount`, but `professionalId` belongs to (first) `account`
-    // hence it should not get to create the PTS
-    const body = {
-      ...getValidParams(),
-      professionalId: professional.getId(),
-      accountId: anotherAccount.getId(),
-    };
+      // the authenticated user is `anotherAccount`, but `professionalId` belongs to (first) `account`
+      // hence it should not get to create the PTS
+      const body = {
+        ...getValidParams(),
+        professionalId: professional.getId(),
+        accountId: anotherAccount.getId(),
+      };
 
-    const response = await request(app.getHttpServer())
-      .post("/v1/pts/create")
-      .set({ authorization: `Bearer ${accessToken}` })
-      .send(body)
-      .expect(403);
+      const response = await request(app.getHttpServer())
+        .post("/v1/pts/create")
+        .set({ authorization: `Bearer ${accessToken}` })
+        .send(body)
+        .expect(403);
 
-    expect(response.body).toHaveProperty("message");
-  });
+      expect(response.body).toHaveProperty("message");
+    },
+  );
 
-  it("should return 403 when the professionalId does not exist at all", async () => {
-    // ensure the ID does not exist
-    const nonExistingProfessionalId = generateUUID();
-    prisma.professional.delete({ where: { id: nonExistingProfessionalId } });
+  it(
+    "should return 403 when the professionalId does not exist at all",
+    { tags: ["storeNewPts"] },
+    async () => {
+      // ensure the ID does not exist
+      const nonExistingProfessionalId = generateUUID();
+      prisma.professional.delete({ where: { id: nonExistingProfessionalId } });
 
-    const response = await request(app.getHttpServer())
-      .post("/v1/pts/create")
-      .set({ authorization: `Bearer ${professionalAccountToken}` })
-      .send({ ...getValidParams(), professionalId: nonExistingProfessionalId })
-      .expect(403);
+      const response = await request(app.getHttpServer())
+        .post("/v1/pts/create")
+        .set({ authorization: `Bearer ${professionalAccountToken}` })
+        .send({ ...getValidParams(), professionalId: nonExistingProfessionalId })
+        .expect(403);
 
-    expect(response.body).toHaveProperty("message");
-  });
+      expect(response.body).toHaveProperty("message");
+    },
+  );
 
-  it("should return 409 when the patient already has an active PTS", async () => {
-    // note that `getValidParams()` returns the same patient, professional and account
-    const params = getValidParams();
+  it(
+    "should return 409 when the patient already has an active PTS",
+    { tags: ["storeNewPts"] },
+    async () => {
+      // note that `getValidParams()` returns the same patient, professional and account
+      const params = getValidParams();
 
-    const pts = await ptsFactory.createAndPersist(prisma, params);
-    pts.acceptAndBeginPlanning();
+      const pts = await ptsFactory.createAndPersist(prisma, params);
+      pts.acceptAndBeginPlanning();
 
-    await prisma.projetoTerapeuticoSingular.update({
-      data: ptsMapper.intoPrisma(pts),
-      where: { id: pts.getId().toString() },
-    });
+      await prisma.projetoTerapeuticoSingular.update({
+        data: ptsMapper.intoPrisma(pts),
+        where: { id: pts.getId().toString() },
+      });
 
-    // second creation for the same patient should fail due to conflict
-    const conflictResponse = await request(app.getHttpServer())
-      .post("/v1/pts/create")
-      .set({ authorization: `Bearer ${professionalAccountToken}` })
-      .send(params)
-      .expect(409);
+      // second creation for the same patient should fail due to conflict
+      const conflictResponse = await request(app.getHttpServer())
+        .post("/v1/pts/create")
+        .set({ authorization: `Bearer ${professionalAccountToken}` })
+        .send(params)
+        .expect(409);
 
-    expect(conflictResponse.body).toHaveProperty("message");
-  });
+      expect(conflictResponse.body).toHaveProperty("message");
+    },
+  );
 
-  it("should draft a PTS successfully", async () => {
+  it("should draft a PTS successfully", { tags: ["storeNewPts"] }, async () => {
     const newPatient = await patientsFactory.createAndPersist(prisma);
 
     const existingPtsForNewPatientPriorToCreation = await prisma.projetoTerapeuticoSingular.count({
@@ -189,68 +203,76 @@ describe("[e2e] PTS Controller (v1)", () => {
     expect(existingPtsForNewPatient, "it should have created a new PTS for the patient").toBe(1);
   });
 
-  it("should require every professional from the multidisciplinary team to exist", async () => {
-    const secondProfessionalNotPersisted = await professionalsFactory.create();
+  it(
+    "should require every professional from the multidisciplinary team to exist",
+    { tags: ["storeNewPts"] },
+    async () => {
+      const secondProfessionalNotPersisted = await professionalsFactory.create();
 
-    const body = {
-      ...getValidParams(),
-      multidisciplinaryTeamIds: [secondProfessionalNotPersisted.getId()],
-    };
+      const body = {
+        ...getValidParams(),
+        multidisciplinaryTeamIds: [secondProfessionalNotPersisted.getId()],
+      };
 
-    await request(app.getHttpServer())
-      .post("/v1/pts/create")
-      .set({ authorization: `Bearer ${professionalAccountToken}` })
-      .send(body)
-      .expect(400);
+      await request(app.getHttpServer())
+        .post("/v1/pts/create")
+        .set({ authorization: `Bearer ${professionalAccountToken}` })
+        .send(body)
+        .expect(400);
 
-    const persistedPts = await prisma.projetoTerapeuticoSingular.count({
-      where: { patientId: patient.getId().toString() },
-    });
+      const persistedPts = await prisma.projetoTerapeuticoSingular.count({
+        where: { patientId: patient.getId().toString() },
+      });
 
-    expect(persistedPts, "it should not have created the PTS").toBe(0);
-  });
+      expect(persistedPts, "it should not have created the PTS").toBe(0);
+    },
+  );
 
-  it("should draft a PTS with multidisciplinary team members successfully", async () => {
-    const newPatient = await patientsFactory.createAndPersist(prisma);
+  it(
+    "should draft a PTS with multidisciplinary team members successfully",
+    { tags: ["storeNewPts"] },
+    async () => {
+      const newPatient = await patientsFactory.createAndPersist(prisma);
 
-    const teamMember1 = await professionalsFactory.createAndPersist(prisma, {
-      accountId: account.getId(),
-    });
+      const teamMember1 = await professionalsFactory.createAndPersist(prisma, {
+        accountId: account.getId(),
+      });
 
-    const teamMember2 = await professionalsFactory.createAndPersist(prisma, {
-      accountId: account.getId(),
-    });
+      const teamMember2 = await professionalsFactory.createAndPersist(prisma, {
+        accountId: account.getId(),
+      });
 
-    const inputMembersIds = [teamMember1.getId(), teamMember2.getId()];
-    const body = {
-      ...getValidParams(),
-      patientId: newPatient.getId(),
-      multidisciplinaryTeamIds: inputMembersIds,
-    };
+      const inputMembersIds = [teamMember1.getId(), teamMember2.getId()];
+      const body = {
+        ...getValidParams(),
+        patientId: newPatient.getId(),
+        multidisciplinaryTeamIds: inputMembersIds,
+      };
 
-    await request(app.getHttpServer())
-      .post("/v1/pts/create")
-      .set({ authorization: `Bearer ${professionalAccountToken}` })
-      .send(body)
-      .expect(201);
+      await request(app.getHttpServer())
+        .post("/v1/pts/create")
+        .set({ authorization: `Bearer ${professionalAccountToken}` })
+        .send(body)
+        .expect(201);
 
-    const newPts = await prisma.projetoTerapeuticoSingular.findFirstOrThrow({
-      where: { patientId: newPatient.getId().toString() },
-      include: { multidisciplinaryTeam: { select: { professionalId: true } } },
-    });
+      const newPts = await prisma.projetoTerapeuticoSingular.findFirstOrThrow({
+        where: { patientId: newPatient.getId().toString() },
+        include: { multidisciplinaryTeam: { select: { professionalId: true } } },
+      });
 
-    const membersInTheMultidisciplinaryTeamOfPts = newPts.multidisciplinaryTeam.map(
-      (team) => team.professionalId,
-    );
+      const membersInTheMultidisciplinaryTeamOfPts = newPts.multidisciplinaryTeam.map(
+        (team) => team.professionalId,
+      );
 
-    expect(
-      membersInTheMultidisciplinaryTeamOfPts,
-      "it should have put every input member in the initial multidisciplinary team",
-    ).toEqual(expect.arrayContaining(inputMembersIds));
+      expect(
+        membersInTheMultidisciplinaryTeamOfPts,
+        "it should have put every input member in the initial multidisciplinary team",
+      ).toEqual(expect.arrayContaining(inputMembersIds));
 
-    expect(
-      membersInTheMultidisciplinaryTeamOfPts.length,
-      "it should not have added more members than requested",
-    ).toBe(inputMembersIds.length);
-  });
+      expect(
+        membersInTheMultidisciplinaryTeamOfPts.length,
+        "it should not have added more members than requested",
+      ).toBe(inputMembersIds.length);
+    },
+  );
 });

--- a/src/modules/therapeutic-journey/dtos/create-pts.dto.ts
+++ b/src/modules/therapeutic-journey/dtos/create-pts.dto.ts
@@ -1,6 +1,6 @@
 import { type UUID } from "@/common/uuid";
 import { DTO } from "@/infra/http/dto";
-import { ApiProperty } from "@nestjs/swagger";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { Expose } from "class-transformer";
 import z from "zod";
 
@@ -10,10 +10,12 @@ const schema = z.object({
     .uuid("O ID do profissional fornecido é inválido.")
     .transform((id) => id as UUID),
   socialSituation: z.string("A situação social precisa ser um texto."),
-  multidisciplinaryTeamIds: z.array(
-    z.uuid("O ID fornecido para este profissional é inválido."),
-    "Você deve enviar os identificadores dos profissionais que comporão a equipe multidisciplinar.",
-  ),
+  multidisciplinaryTeamIds: z
+    .array(
+      z.uuid("O ID fornecido para este profissional é inválido."),
+      "Você deve enviar os identificadores dos profissionais que comporão a equipe multidisciplinar.",
+    )
+    .optional(),
 });
 
 type CreatePtsSchema = z.infer<typeof schema>;
@@ -43,7 +45,7 @@ export class CreatePtsDto extends DTO implements CreatePtsSchema {
   public readonly socialSituation!: string;
 
   @Expose()
-  @ApiProperty({
+  @ApiPropertyOptional({
     description:
       "The identifiers of the initial professionals composing the multidisciplinary team of this PTS.",
     type: "array",
@@ -53,5 +55,5 @@ export class CreatePtsDto extends DTO implements CreatePtsSchema {
         "The identifier of one professional to be member of the multidisciplinary team of this PTS.",
     },
   })
-  public readonly multidisciplinaryTeamIds!: string[];
+  public readonly multidisciplinaryTeamIds?: string[];
 }

--- a/src/modules/therapeutic-journey/dtos/create-pts.dto.ts
+++ b/src/modules/therapeutic-journey/dtos/create-pts.dto.ts
@@ -1,0 +1,57 @@
+import { type UUID } from "@/common/uuid";
+import { DTO } from "@/infra/http/dto";
+import { ApiProperty } from "@nestjs/swagger";
+import { Expose } from "class-transformer";
+import z from "zod";
+
+const schema = z.object({
+  patientId: z.uuid("O ID fornecido para o paciente é inválido.").transform((id) => id as UUID),
+  professionalId: z
+    .uuid("O ID do profissional fornecido é inválido.")
+    .transform((id) => id as UUID),
+  socialSituation: z.string("A situação social precisa ser um texto."),
+  multidisciplinaryTeamIds: z.array(
+    z.uuid("O ID fornecido para este profissional é inválido."),
+    "Você deve enviar os identificadores dos profissionais que comporão a equipe multidisciplinar.",
+  ),
+});
+
+type CreatePtsSchema = z.infer<typeof schema>;
+
+export class CreatePtsDto extends DTO implements CreatePtsSchema {
+  protected schema = schema;
+
+  @Expose()
+  @ApiProperty({
+    description: "The ID of the professional (profile) with which you intend to create this PTS.",
+    type: "string",
+  })
+  public readonly professionalId!: UUID;
+
+  @Expose()
+  @ApiProperty({
+    description: "The ID of the patient to whom the PTS is being drafted to.",
+    type: "string",
+  })
+  public readonly patientId!: UUID;
+
+  @Expose()
+  @ApiProperty({
+    description: "The initial analytics and description of the social situation of the patient.",
+    type: "string",
+  })
+  public readonly socialSituation!: string;
+
+  @Expose()
+  @ApiProperty({
+    description:
+      "The identifiers of the initial professionals composing the multidisciplinary team of this PTS.",
+    type: "array",
+    items: {
+      type: "string",
+      description:
+        "The identifier of one professional to be member of the multidisciplinary team of this PTS.",
+    },
+  })
+  public readonly multidisciplinaryTeamIds!: string[];
+}

--- a/src/modules/therapeutic-journey/errors/professional-does-not-belong-to-user-account.error.ts
+++ b/src/modules/therapeutic-journey/errors/professional-does-not-belong-to-user-account.error.ts
@@ -1,0 +1,8 @@
+import { ForbiddenError } from "@/common/errors/forbidden.error";
+import type { UUID } from "@/common/uuid";
+
+export class ProfessionalDoesNotBelongToUserAccountError extends ForbiddenError {
+  public constructor(professionalId: UUID) {
+    super({ message: `O profissional de ID "${professionalId}" não está associado a você.` });
+  }
+}

--- a/src/modules/therapeutic-journey/errors/professional-is-not-registered.error.ts
+++ b/src/modules/therapeutic-journey/errors/professional-is-not-registered.error.ts
@@ -1,0 +1,12 @@
+import { BadRequestError } from "@/common/errors/bad-request.error";
+
+export class ProfessionalIsNotRegistered extends BadRequestError {
+  public constructor(public readonly level: "responsible" | "team") {
+    super({
+      message:
+        level === "responsible"
+          ? "Este profissional não está apropriadamente registrado na plataforma."
+          : "Ao menos um dos profissionais da equipe não está registrado na plataforma apropriadamente.",
+    });
+  }
+}

--- a/src/modules/therapeutic-journey/repositories/pts.repository.ts
+++ b/src/modules/therapeutic-journey/repositories/pts.repository.ts
@@ -1,6 +1,7 @@
 import { IrrecoverableError } from "@/common/errors/irrecoverable.error";
 import { type UUID } from "@/common/uuid";
 import { ProjetoTerapeuticoSingular } from "@/modules/therapeutic-journey/aggregates/pts.aggregate";
+import { ProfessionalIsNotRegistered } from "@/modules/therapeutic-journey/errors/professional-is-not-registered.error";
 import { Either } from "fp-ts/lib/Either";
 
 export abstract class PtsRepository {
@@ -13,7 +14,11 @@ export abstract class PtsRepository {
     patientId: UUID,
   ): Promise<Either<IrrecoverableError, boolean>>;
 
+  /**
+   * Saves the newly created `pts`. Shall not create it successfully if any of the professionals
+   * involved (the responsible or any from the multidisciplinary team) does not exist within the platform.
+   */
   public abstract createNewPts(
     pts: ProjetoTerapeuticoSingular,
-  ): Promise<Either<IrrecoverableError, ProjetoTerapeuticoSingular>>;
+  ): Promise<Either<IrrecoverableError | ProfessionalIsNotRegistered, ProjetoTerapeuticoSingular>>;
 }

--- a/src/modules/therapeutic-journey/services/create-draft-pts.service.ts
+++ b/src/modules/therapeutic-journey/services/create-draft-pts.service.ts
@@ -69,16 +69,10 @@ export class CreateDraftPtsService {
   private ensureNoActivePts(patientId: UUID) {
     return pipe(
       () => this.ptsRepo.activePtsExistsByPatientId(patientId),
-      te.chainW(
-        te.fromPredicate(
-          (ptsAlreadyExists) => {
-            const canCreateNewPts = !ptsAlreadyExists;
-            return canCreateNewPts;
-          },
-          () => new PatientAlreadyHasActivePtsError(),
-        ),
-      ),
-      te.map(() => {}),
+      te.chainEitherKW((thereIsAnActivePts) => {
+        if (thereIsAnActivePts) return e.left(new PatientAlreadyHasActivePtsError());
+        return e.right(undefined);
+      }),
     );
   }
 }

--- a/src/modules/therapeutic-journey/services/create-draft-pts.service.ts
+++ b/src/modules/therapeutic-journey/services/create-draft-pts.service.ts
@@ -1,14 +1,23 @@
 import { Injectable } from "@nestjs/common";
 import { pipe } from "fp-ts/lib/function";
-import { taskEither as te } from "fp-ts";
+import { either as e, taskEither as te } from "fp-ts";
 import { PtsRepository } from "@/modules/therapeutic-journey/repositories/pts.repository";
 import { AccountsRepository } from "@/modules/identity/repositories/accounts.repository";
 import { ProjetoTerapeuticoSingular } from "@/modules/therapeutic-journey/aggregates/pts.aggregate";
 import { ProfessionalsRepository } from "@/modules/professional/professionals.repository";
 import type { UUID } from "@/common/uuid";
 import { PatientAlreadyHasActivePtsError } from "@/modules/therapeutic-journey/errors/patient-already-has-active-pts.error";
+import { Professional } from "@/modules/professional/entities/professional.aggregate";
+import { ProfessionalDoesNotBelongToUserAccountError } from "@/modules/therapeutic-journey/errors/professional-does-not-belong-to-user-account.error";
 
 type Params = {
+  /**
+   * The ID of the account of the professional (profile) trying to create the PTS.
+   */
+  accountId: UUID;
+  /**
+   * The ID of the professional profile under which the user is trying to create the PTS.
+   */
   professionalId: UUID;
   patientId: UUID;
   socialSituation: string;
@@ -23,11 +32,20 @@ export class CreateDraftPtsService {
     private readonly professionalsRepo: ProfessionalsRepository,
   ) {}
 
-  public execute({ professionalId, patientId, socialSituation, multidisciplinaryTeamIds }: Params) {
+  public execute({
+    professionalId,
+    patientId,
+    socialSituation,
+    multidisciplinaryTeamIds,
+    accountId,
+  }: Params) {
     return pipe(
       te.Do,
       te.apS("patientAccount", () => this.accountsRepo.findAccountById(patientId)),
       te.apS("professional", () => this.professionalsRepo.findById(professionalId)),
+      te.chainFirstEitherKW(({ professional }) =>
+        this.ensureProfessionalProfileBelongsToUser(professional, accountId),
+      ),
       te.chainFirstW(({ patientAccount }) => this.ensureNoActivePts(patientAccount.getId())),
       te.bindW("pts", ({ patientAccount, professional }) => {
         const pts = ProjetoTerapeuticoSingular.create({
@@ -41,6 +59,11 @@ export class CreateDraftPtsService {
       }),
       te.chainW((args) => () => this.ptsRepo.createNewPts(args.pts)),
     )();
+  }
+
+  private ensureProfessionalProfileBelongsToUser(professional: Professional, accountId: UUID) {
+    if (professional.belongsToAccount(accountId)) return e.right(undefined);
+    return e.left(new ProfessionalDoesNotBelongToUserAccountError(professional.getId()));
   }
 
   private ensureNoActivePts(patientId: UUID) {

--- a/src/modules/therapeutic-journey/services/create-draft-pts.spec.ts
+++ b/src/modules/therapeutic-journey/services/create-draft-pts.spec.ts
@@ -18,34 +18,35 @@ describe("[Service] Create Draft PTS Service", async () => {
   let sut: CreateDraftPtsService;
 
   beforeEach(() => {
-    ptsRepository = new InMemoryPtsRepository();
     accountsRepository = new InMemoryAccountsRepository();
     professionalsRepository = new InMemoryProfessionalsRepository();
+    ptsRepository = new InMemoryPtsRepository(professionalsRepository);
     sut = new CreateDraftPtsService(ptsRepository, accountsRepository, professionalsRepository);
   });
 
   const getEntities = async () => {
     const patientAccount = await accountsFactory.create();
-    const patientResult = await patientsFactory.create({ accountId: patientAccount.getId() });
+    const profesisonalAccount = await accountsFactory.create();
 
-    assert(either.isRight(patientResult));
+    const patient = await patientsFactory.create({ accountId: patientAccount.getId() });
+    const professional = await professionalsFactory.create({
+      accountId: profesisonalAccount.getId(),
+    });
 
-    const patient = patientResult.right;
-    const professional = await professionalsFactory.create();
-
-    accountsRepository.accounts.push(patientAccount);
+    accountsRepository.accounts.push(patientAccount, profesisonalAccount);
     professionalsRepository.professionals.push(professional);
 
-    return { patientAccount, patient, professional };
+    return { patientAccount, patient, profesisonalAccount, professional };
   };
 
   test("successfull creation contracts", async () => {
-    const { patient, professional } = await getEntities();
+    const { patient, professional, profesisonalAccount } = await getEntities();
 
     const result = await sut.execute({
       patientId: patient.getId(),
       professionalId: professional.getId(),
       socialSituation: faker.lorem.paragraphs(5),
+      accountId: profesisonalAccount.getId(),
     });
 
     assert(either.isRight(result), "it should have created the PTS successfully");
@@ -69,12 +70,13 @@ describe("[Service] Create Draft PTS Service", async () => {
   });
 
   it("should allow to create a PTS with a initial multidisciplinary team defined", async () => {
-    const { patient, professional } = await getEntities();
+    const { patient, professional, profesisonalAccount } = await getEntities();
 
     const professionals = await Promise.all(
       Array.from({ length: 10 }).map(() => professionalsFactory.create()),
     );
 
+    professionalsRepository.professionals.push(...professionals);
     const multidisciplinaryTeamIds = professionals.map((professional) => professional.getId());
 
     const result = await sut.execute({
@@ -82,6 +84,7 @@ describe("[Service] Create Draft PTS Service", async () => {
       professionalId: professional.getId(),
       socialSituation: faker.lorem.paragraphs(5),
       multidisciplinaryTeamIds,
+      accountId: profesisonalAccount.getId(),
     });
 
     assert(either.isRight(result));
@@ -93,11 +96,13 @@ describe("[Service] Create Draft PTS Service", async () => {
   });
 
   it("should silently refuse to include the responsible professional in the list of ids of the professionals from the multidisciplinary team", async () => {
-    const { patient, professional } = await getEntities();
+    const { patient, professional, profesisonalAccount } = await getEntities();
 
     const professionals = await Promise.all(
       Array.from({ length: 10 }).map(() => professionalsFactory.create()),
     );
+
+    professionalsRepository.professionals.push(...professionals);
 
     const multidisciplinaryTeamIds = [
       professional.getId(),
@@ -109,6 +114,7 @@ describe("[Service] Create Draft PTS Service", async () => {
       professionalId: professional.getId(),
       socialSituation: faker.lorem.paragraphs(5),
       multidisciplinaryTeamIds,
+      accountId: profesisonalAccount.getId(),
     });
 
     assert(either.isRight(result));
@@ -121,20 +127,17 @@ describe("[Service] Create Draft PTS Service", async () => {
   });
 
   it("should not let no professional create a new PTS for a patient that already has an active PTS", async () => {
-    const { patient, professional } = await getEntities();
+    const { patient, professional, profesisonalAccount } = await getEntities();
 
-    const ptsResult = await ptsFactory.create({ patientId: patient.getId() });
-    assert(either.isRight(ptsResult));
-
-    const pts = ptsResult.right;
-    assert(either.isRight(pts.acceptAndBeginPlanning()));
-
+    const pts = await ptsFactory.create({ patientId: patient.getId() });
+    pts.acceptAndBeginPlanning();
     ptsRepository.items.push(pts);
 
     const result = await sut.execute({
       patientId: patient.getId(),
       professionalId: professional.getId(),
       socialSituation: faker.lorem.paragraphs(5),
+      accountId: profesisonalAccount.getId(),
     });
 
     assert(
@@ -150,7 +153,7 @@ describe("[Service] Create Draft PTS Service", async () => {
   });
 
   it("should not allow any entity but a professional to create a PTS", async () => {
-    const { patient } = await getEntities();
+    const { patient, profesisonalAccount } = await getEntities();
     const anotherAccount = await accountsFactory.create();
     accountsRepository.accounts.push(anotherAccount);
 
@@ -158,6 +161,7 @@ describe("[Service] Create Draft PTS Service", async () => {
       patientId: patient.getId(),
       professionalId: anotherAccount.getId(),
       socialSituation: faker.lorem.paragraph(),
+      accountId: profesisonalAccount.getId(),
     });
 
     assert(

--- a/src/modules/therapeutic-journey/services/create-draft-pts.spec.ts
+++ b/src/modules/therapeutic-journey/services/create-draft-pts.spec.ts
@@ -69,6 +69,8 @@ describe("[Service] Create Draft PTS Service", async () => {
     ).toBe(0);
   });
 
+  it("should ensure the professional profile belongs to the user trying to create the PTS", async () => {});
+
   it("should allow to create a PTS with a initial multidisciplinary team defined", async () => {
     const { patient, professional, profesisonalAccount } = await getEntities();
 

--- a/src/modules/therapeutic-journey/therapeutic-journey.module.ts
+++ b/src/modules/therapeutic-journey/therapeutic-journey.module.ts
@@ -1,0 +1,9 @@
+import { PtsController } from "@/modules/therapeutic-journey/controllers/pts.controller";
+import { CreateDraftPtsService } from "@/modules/therapeutic-journey/services/create-draft-pts.service";
+import { Module } from "@nestjs/common";
+
+@Module({
+  controllers: [PtsController],
+  providers: [CreateDraftPtsService],
+})
+export class TherapeuticJourneyModule {}

--- a/test/factories/accounts.factory.ts
+++ b/test/factories/accounts.factory.ts
@@ -17,7 +17,7 @@ async function create(
     email = faker.internet.email(),
     name = faker.person.fullName(),
     passwordHash,
-    plainPassword = randomBytes(30).toString(),
+    plainPassword = randomBytes(64).toString("base64"),
   }: Params = {},
   { hasher = new MockHasherAndComparator() }: BaseOptions = {},
 ) {

--- a/test/factories/patients.factory.ts
+++ b/test/factories/patients.factory.ts
@@ -3,22 +3,28 @@ import patientsMapper from "@/infra/prisma/mappers/patients.mapper";
 import { PrismaService } from "@/infra/prisma/prisma";
 import { Patient } from "@/modules/patient/entities/patient.entity";
 import { resolveAccount } from "@test/factories/utils";
-import { taskEither } from "fp-ts";
+import { either, taskEither } from "fp-ts";
 import { pipe } from "fp-ts/lib/function";
 
 type Params = Partial<Patient.Props>;
 
 async function create({ accountId = generateUUID(), supportContacts = [] }: Params = {}) {
-  return Patient.create({ accountId, supportContacts });
+  return pipe(
+    Patient.create({ accountId, supportContacts }),
+    either.getOrElseW((error) => {
+      throw error;
+    }),
+  );
 }
 
 async function createAndPersist(prismaService: PrismaService, params?: Params) {
   let account = await resolveAccount(prismaService, params?.accountId);
+  const patient = await create({ ...params, accountId: account.getId() });
 
   return await pipe(
-    () => create({ ...params, accountId: account.getId() }),
-    taskEither.map(patientsMapper.intoPrisma),
-    taskEither.chain((data) => taskEither.fromTask(() => prismaService.patient.create({ data }))),
+    taskEither.fromTask(() =>
+      prismaService.patient.create({ data: patientsMapper.intoPrisma(patient) }),
+    ),
     taskEither.map(patientsMapper.fromPrisma),
     taskEither.getOrElse((error) => error),
   )();

--- a/test/factories/patients.factory.ts
+++ b/test/factories/patients.factory.ts
@@ -20,6 +20,7 @@ async function createAndPersist(prismaService: PrismaService, params?: Params) {
     taskEither.map(patientsMapper.intoPrisma),
     taskEither.chain((data) => taskEither.fromTask(() => prismaService.patient.create({ data }))),
     taskEither.map(patientsMapper.fromPrisma),
+    taskEither.getOrElse((error) => error),
   )();
 }
 

--- a/test/factories/professionals.factory.ts
+++ b/test/factories/professionals.factory.ts
@@ -29,6 +29,9 @@ async function createAndPersist(prismaService: PrismaService, params?: Params) {
       taskEither.fromTask(() => prismaService.professional.create({ data })),
     ),
     taskEither.map(professionalMapper.fromPrisma),
+    // we don't really care atp, it's just for testing purposes, if it fails, it means there is a problem
+    // in the test... just go fix it
+    taskEither.getOrElse((error) => error),
   )();
 }
 

--- a/test/factories/pts.factory.ts
+++ b/test/factories/pts.factory.ts
@@ -65,15 +65,7 @@ async function createAndPersist(prismaService: PrismaService, params?: CreatePar
         }),
       ),
     ),
-    taskEither.map((row) => {
-      const { multidisciplinaryTeam, ...rawPts } = row;
-
-      const multidisciplinaryTeamIds = multidisciplinaryTeam.map(
-        ({ professionalId }) => professionalId,
-      );
-
-      ptsMapper.fromPrisma({ ...rawPts, multidisciplinaryTeamIds });
-    }),
+    taskEither.map((row) => ptsMapper.fromPrisma(row)),
   )();
 }
 

--- a/test/factories/pts.factory.ts
+++ b/test/factories/pts.factory.ts
@@ -6,6 +6,7 @@ import { PtsTimeline } from "@/modules/therapeutic-journey/value-objects/pts-tim
 import { faker } from "@faker-js/faker";
 import patientsFactory from "@test/factories/patients.factory";
 import professionalsFactory from "@test/factories/professionals.factory";
+import { resolvePatient, resolveProfessional } from "@test/factories/utils";
 import { either, taskEither } from "fp-ts";
 import { pipe } from "fp-ts/lib/function";
 
@@ -52,20 +53,35 @@ async function create({
 }
 
 async function createAndPersist(prismaService: PrismaService, params?: CreateParams) {
+  const patient = await resolvePatient(prismaService, params?.patientId);
+
+  const responsibleProfessional = await resolveProfessional(
+    prismaService,
+    params?.responsibleProfessionalId,
+  );
+
   return await pipe(
-    () => create(params),
+    () =>
+      create({
+        ...params,
+        responsibleProfessionalId: responsibleProfessional.getId(),
+        patientId: patient.getId(),
+      }),
     taskEither.map(ptsMapper.intoPrisma),
     taskEither.chain((data) =>
-      taskEither.fromTask(() =>
-        prismaService.projetoTerapeuticoSingular.create({
-          data,
-          include: {
-            multidisciplinaryTeam: { select: { professionalId: true } },
-          },
-        }),
+      taskEither.tryCatch(
+        () =>
+          prismaService.projetoTerapeuticoSingular.create({
+            data,
+            include: { multidisciplinaryTeam: { select: { professionalId: true } } },
+          }),
+        (error) => error,
       ),
     ),
     taskEither.map((row) => ptsMapper.fromPrisma(row)),
+    taskEither.getOrElse((error) => {
+      throw error;
+    }),
   )();
 }
 

--- a/test/factories/pts.factory.ts
+++ b/test/factories/pts.factory.ts
@@ -7,7 +7,7 @@ import { faker } from "@faker-js/faker";
 import patientsFactory from "@test/factories/patients.factory";
 import professionalsFactory from "@test/factories/professionals.factory";
 import { resolvePatient, resolveProfessional } from "@test/factories/utils";
-import { either, taskEither } from "fp-ts";
+import { taskEither } from "fp-ts";
 import { pipe } from "fp-ts/lib/function";
 
 type CreateTimeLineParams = Partial<Parameters<typeof PtsTimeline.createUnchecked>[0]>;
@@ -31,25 +31,16 @@ async function create({
   timeline = createTimeline(),
 }: CreateParams = {}) {
   responsibleProfessionalId ??= (await professionalsFactory.create()).getId();
+  patientId ??= (await patientsFactory.create()).getId();
 
-  return pipe(
-    patientId
-      ? either.right(patientId)
-      : pipe(
-          await patientsFactory.create(),
-          either.map((patient) => patient.getId()),
-        ),
-    either.map((patientId) =>
-      ProjetoTerapeuticoSingular.createUnchecked({
-        patientId,
-        responsibleProfessionalId,
-        socialSituation,
-        id,
-        multidisciplinaryTeamIds,
-        timeline,
-      }),
-    ),
-  );
+  return ProjetoTerapeuticoSingular.createUnchecked({
+    patientId,
+    responsibleProfessionalId,
+    socialSituation,
+    id,
+    multidisciplinaryTeamIds,
+    timeline,
+  });
 }
 
 async function createAndPersist(prismaService: PrismaService, params?: CreateParams) {
@@ -60,23 +51,20 @@ async function createAndPersist(prismaService: PrismaService, params?: CreatePar
     params?.responsibleProfessionalId,
   );
 
+  const pts = await create({
+    ...params,
+    responsibleProfessionalId: responsibleProfessional.getId(),
+    patientId: patient.getId(),
+  });
+
   return await pipe(
-    () =>
-      create({
-        ...params,
-        responsibleProfessionalId: responsibleProfessional.getId(),
-        patientId: patient.getId(),
-      }),
-    taskEither.map(ptsMapper.intoPrisma),
-    taskEither.chain((data) =>
-      taskEither.tryCatch(
-        () =>
-          prismaService.projetoTerapeuticoSingular.create({
-            data,
-            include: { multidisciplinaryTeam: { select: { professionalId: true } } },
-          }),
-        (error) => error,
-      ),
+    taskEither.tryCatch(
+      () =>
+        prismaService.projetoTerapeuticoSingular.create({
+          data: ptsMapper.intoPrisma(pts),
+          include: { multidisciplinaryTeam: { select: { professionalId: true } } },
+        }),
+      (error) => error,
     ),
     taskEither.map((row) => ptsMapper.fromPrisma(row)),
     taskEither.getOrElse((error) => {

--- a/test/factories/pts.factory.ts
+++ b/test/factories/pts.factory.ts
@@ -73,4 +73,4 @@ async function createAndPersist(prismaService: PrismaService, params?: CreatePar
   )();
 }
 
-export default { create, createAndPersist };
+export default { create, createAndPersist, createTimeline };

--- a/test/factories/utils.ts
+++ b/test/factories/utils.ts
@@ -5,6 +5,10 @@ import accountsFactory from "@test/factories/accounts.factory";
 // Used for the docstrings; removed during build since it's type import
 // oxlint-disable-next-line no-unused-vars
 import { type PrismaClientKnownRequestError } from "@prisma-gen/internal/prismaNamespace";
+import professionalsFactory from "@test/factories/professionals.factory";
+import professionalsMapper from "@/infra/prisma/mappers/professionals.mapper";
+import patientsFactory from "@test/factories/patients.factory";
+import patientsMapper from "@/infra/prisma/mappers/patients.mapper";
 
 /**
  * Decides whether to create a new `Account` instance for the callee
@@ -24,4 +28,44 @@ export async function resolveAccount(prismaService: PrismaService, accountId?: U
   });
 
   return accountsMapper.fromPrisma(accountRow);
+}
+
+/**
+ * Decides whether to create a new `Professional` instance for the callee
+ * or to fetch the existing one by `professionalId`.
+
+ * @note must be used by test factories only.
+ *
+ * @throws a {@link PrismaClientKnownRequestError `PrismaClientKnownRequestError`} when there
+ * is no persisted account with ID `accountId`.
+ */
+export async function resolveProfessional(prismaService: PrismaService, professionalId?: UUID) {
+  if (!professionalId) return await professionalsFactory.createAndPersist(prismaService);
+
+  const professional = await prismaService.professional.findFirstOrThrow({
+    where: { id: professionalId.toString() },
+    include: { account: true },
+  });
+
+  return professionalsMapper.fromPrisma(professional);
+}
+
+/**
+ * Decides whether to create a new `Patient` for the callee or retrieve the
+ * existing one by `patientId`.
+ *
+ * @note must be used by test factories only.
+ *
+ * @throws a {@link PrismaClientKnownRequestError `PrismaClientKnownRequestError`} when there
+ * is no persisted account with ID `accountId`.
+ */
+export async function resolvePatient(prismaService: PrismaService, patientId?: UUID) {
+  if (!patientId) return await patientsFactory.createAndPersist(prismaService);
+
+  const patient = await prismaService.patient.findFirstOrThrow({
+    where: { accountId: patientId.toString() },
+    include: { account: true },
+  });
+
+  return patientsMapper.fromPrisma(patient);
 }

--- a/test/mocks/repositories/in-memory/pts.repository.ts
+++ b/test/mocks/repositories/in-memory/pts.repository.ts
@@ -1,12 +1,19 @@
 import { IrrecoverableError } from "@/common/errors/irrecoverable.error";
 import { UUID } from "@/common/uuid";
 import { ProjetoTerapeuticoSingular } from "@/modules/therapeutic-journey/aggregates/pts.aggregate";
+import { ProfessionalIsNotRegistered } from "@/modules/therapeutic-journey/errors/professional-is-not-registered.error";
 import { PtsRepository } from "@/modules/therapeutic-journey/repositories/pts.repository";
+import { InMemoryProfessionalsRepository } from "@test/mocks/repositories/in-memory/professionals.repository";
 import { either } from "fp-ts";
 import { Either } from "fp-ts/lib/Either";
 
 export class InMemoryPtsRepository extends PtsRepository {
-  public items: ProjetoTerapeuticoSingular[] = [];
+  public constructor(
+    public professionalsRepo: InMemoryProfessionalsRepository = new InMemoryProfessionalsRepository(),
+    public items: ProjetoTerapeuticoSingular[] = [],
+  ) {
+    super();
+  }
 
   public async activePtsExistsByPatientId(
     patientId: UUID,
@@ -16,9 +23,26 @@ export class InMemoryPtsRepository extends PtsRepository {
     return either.right(Boolean(activePts));
   }
 
-  public async createNewPts(
-    pts: ProjetoTerapeuticoSingular,
-  ): Promise<Either<IrrecoverableError, ProjetoTerapeuticoSingular>> {
+  public async createNewPts(pts: ProjetoTerapeuticoSingular) {
+    const snapshot = pts.toSnapshot();
+
+    const responsibleProfessional = this.professionalsRepo.professionals.some(
+      (professional) => professional.getId() === snapshot.responsibleProfessionalId,
+    );
+
+    if (!responsibleProfessional) {
+      return either.left(new ProfessionalIsNotRegistered("responsible"));
+    }
+
+    const everyProfessionalFromMultidisciplinaryTeamExists =
+      snapshot.multidisciplinaryTeamIds.every((id) =>
+        this.professionalsRepo.professionals.some((professional) => professional.getId() === id),
+      );
+
+    if (!everyProfessionalFromMultidisciplinaryTeamExists) {
+      return either.left(new ProfessionalIsNotRegistered("team"));
+    }
+
     this.items.push(pts);
     return either.right(pts);
   }

--- a/test/setup-e2e.ts
+++ b/test/setup-e2e.ts
@@ -9,6 +9,11 @@ beforeAll(async () => {
   execSync("npx prisma migrate deploy");
 }, 60000);
 
+beforeEach(() => {
+  // This resets the database so that every single test run with a fresh database instnace
+  execSync("npx prisma migrate reset --force");
+}, 60000);
+
 afterAll(async () => {
   await container?.stop();
 }, 60000);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   test: {
     globals: true,
     root: "./",
+    strictTags: false,
   },
   resolve: {
     tsconfigPaths: true,

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     root: "./",
     setupFiles: ["./test/setup-e2e.ts"],
     testTimeout: 40000,
+    strictTags: false,
   },
   resolve: {
     tsconfigPaths: true,


### PR DESCRIPTION
Esse PR adiciona o endpoint para criação de um PTS, bem como implementa o repositório de PTS com Prisma.
Além disso, esse PR também realiza as seguintes correções/alterações:

## Outras adições
- O usuário autenticado agora pode ser obtido através do _decorator_ `@CurrentUser` — que retorna uma instância de `AuthCollection`.

## Correções
- Agora não é mais possível que um usuário crie um PTS usando um perfil profissional que não lhe pertence.
- A tentativa de criar um PTS com um perfil de profissional inexistente agora retorna o erro `ProfessionalIsNotRegistered`.
- A tentativa de criar um PTS com profissionais inexistentes compondo a equipe multidisciplinar agora causa o erro `ProfessionalIsNotRegistered`.
- As factories (mocks) foram corrigidas para corretamente persistir as sub-entidades que as compõe ou das quais dependem. Isso corrige erros que aconteceriam no teste de violação das _constraints_ de chaves estrangeiras quando se criasse um PTS sem passar profissionais e pacientes já persistidos como parâmetro.

## Mudanças
- Desabilitada a opção de tags estritas nas configurações do Vitest.

Closes #64 